### PR TITLE
Shared pointers with arrays are c++17 feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18.0...${CMAKE_VERSION})
 
-project(Omega_h VERSION 10.3.0 LANGUAGES CXX)
+project(Omega_h VERSION 10.4.0 LANGUAGES CXX)
 set(Omega_h_USE_STK_DEFAULT OFF)
 option(Omega_h_USE_STK "Whether to build the STK interface" ${Omega_h_USE_STK_DEFAULT})
 

--- a/src/Omega_h_array.hpp
+++ b/src/Omega_h_array.hpp
@@ -192,7 +192,7 @@ class HostRead {
 #if defined(OMEGA_H_USE_KOKKOS)
   typename Kokkos::View<const T*, Kokkos::HostSpace> mirror_;
 #elif defined(OMEGA_H_USE_CUDA)
-  std::shared_ptr<T[]> mirror_;
+  std::shared_ptr<T> mirror_;
 #endif
  public:
   typedef T value_type;
@@ -208,7 +208,7 @@ class HostRead {
     return mirror_(i);
 #else
 #ifdef OMEGA_H_USE_CUDA
-    return mirror_[i];
+    return mirror_.get()[i];
 #else
     return read_[i];
 #endif
@@ -225,7 +225,7 @@ class HostWrite {
 #ifdef OMEGA_H_USE_KOKKOS
   typename Kokkos::View<T*>::HostMirror mirror_;
 #elif defined(OMEGA_H_USE_CUDA)
-  std::shared_ptr<T[]> mirror_;
+  std::shared_ptr<T> mirror_;
 #endif
  public:
   typedef T value_type;
@@ -245,7 +245,7 @@ class HostWrite {
     return mirror_(i);
 #else
 #ifdef OMEGA_H_USE_CUDA
-    return mirror_[i];
+    return mirror_.get()[i];
 #else
     return write_[i];
 #endif

--- a/src/Omega_h_mesh.hpp
+++ b/src/Omega_h_mesh.hpp
@@ -215,7 +215,8 @@ class Mesh {
   template <typename T>
   void change_tagToMesh(Int ent_dim, Int ncomps, std::string const& name,
       LOs class_ids, bool remove = true);
-
+// Don't use these functions... they need to be public for OOMEGA_H_LAMBDA
+ public:
   template <typename T>
   [[nodiscard]] Read<T> get_rc_mesh_array(
       Int ent_dim, Int ncomps, std::string const& name, LOs class_ids);


### PR DESCRIPTION
Using shared pointers with arrays is a c++ 17 feature. For compatibillty with gcc/6.3.0 we need to only support pure c++14 features.

@dhyan1272