### PR TITLE
build with gcc/6.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18.0...${CMAKE_VERSION})
 
-project(Omega_h VERSION 10.4.0 LANGUAGES CXX)
+project(Omega_h VERSION 10.5.0 LANGUAGES CXX)
 set(Omega_h_USE_STK_DEFAULT OFF)
 option(Omega_h_USE_STK "Whether to build the STK interface" ${Omega_h_USE_STK_DEFAULT})
 

--- a/src/Omega_h_defines.hpp
+++ b/src/Omega_h_defines.hpp
@@ -83,7 +83,7 @@ typedef I64 GO;
 typedef double Real;
 
 template <typename F>
-auto apply_to_omega_h_types(Omega_h_Type type, const F& f) {
+auto apply_to_omega_h_types(Omega_h_Type type, const F&& f) {
   switch (type) {
     case OMEGA_H_I8: {
       return f(I8{});

--- a/src/Omega_h_file.cpp
+++ b/src/Omega_h_file.cpp
@@ -293,7 +293,7 @@ static void write_tag(std::ostream& stream, TagBase const* tag,
     using T = decltype(type);
     write_array(stream, as<T>(tag)->array(), is_compressed, needs_swapping);
   };
-  apply_to_omega_h_types(tag->type(), f);
+  apply_to_omega_h_types(tag->type(), std::move(f));
 }
 static void write_rc_tag(std::ostream& stream, TagBase const* tag,
     Int ent_dim, Mesh *mesh, bool is_compressed, bool needs_swapping) {
@@ -343,7 +343,7 @@ static void read_tag(std::istream& stream, Mesh* mesh, Int d,
       mesh->add_tag(d, name, ncomps, array, true);
     }
   };
-  apply_to_omega_h_types(static_cast<Omega_h_Type>(type), f);
+  apply_to_omega_h_types(static_cast<Omega_h_Type>(type), std::move(f));
 }
 
 static void write_sets(std::ostream& stream, Mesh* mesh, bool needs_swapping) {


### PR DESCRIPTION
Due to a compiler defect in gcc (see
https://stackoverflow.com/questions/32097759/calling-this-member-function-from-generic-lambda-clang-vs-gcc)
the methods from the enclosing class require qualification with `this->`

This fixes #38