### PR TITLE
Add Memory Pool for Kokkos Backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ install_manifest.txt
 Makefile
 cmake_install.cmake
 /build*
+/cmake-build-*
 /.vs
+/.idea
 /out/build/x64-Debug
 /CMakeSettings.json
 /out/build/x64-Release

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -180,13 +180,21 @@ if(Omega_h_USE_DOLFIN)
   set(Omega_h_SOURCES ${Omega_h_SOURCES} Omega_h_dolfin.cpp)
 endif()
 
+if(Omega_h_USE_Kokkos)
+  list(APPEND Omega_h_SOURCES Omega_h_array_kokkos.hpp)
+  list(APPEND Omega_h_SOURCES Omega_h_pool_kokkos.hpp)
+  list(APPEND Omega_h_SOURCES Omega_h_pool_kokkos.cpp)
+else()
+  list(APPEND Omega_h_SOURCES Omega_h_array_default.hpp)
+endif()
+
 if (Omega_h_USE_CUDA AND NOT Omega_h_USE_Kokkos)
   set_source_files_properties(${Omega_h_SOURCES} PROPERTIES LANGUAGE CUDA)
 endif()
 
 add_library(omega_h ${Omega_h_SOURCES})
 
-set_property(TARGET omega_h PROPERTY CXX_STANDARD "14")
+set_property(TARGET omega_h PROPERTY CXX_STANDARD "17")
 set_property(TARGET omega_h PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET omega_h PROPERTY CXX_EXTENSIONS OFF)
 
@@ -250,7 +258,7 @@ function(osh_add_exe EXE_NAME)
     set_source_files_properties(${EXE_NAME}.cpp PROPERTIES LANGUAGE CUDA)
   endif()
   add_executable(${EXE_NAME} ${EXE_NAME}.cpp)
-  set_property(TARGET ${EXE_NAME} PROPERTY CXX_STANDARD "14")
+  set_property(TARGET ${EXE_NAME} PROPERTY CXX_STANDARD "17")
   set_property(TARGET ${EXE_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
   set_property(TARGET ${EXE_NAME} PROPERTY CXX_EXTENSIONS OFF)
   set_property(TARGET ${EXE_NAME} PROPERTY CUDA_ARCHITECTURES ${Omega_h_CUDA_ARCH})
@@ -315,6 +323,11 @@ if(BUILD_TESTING)
   endif()
 
   function(test_func_impl TEST_NAME NUM_PROCS)
+
+    if (ENABLE_CTEST_MEMPOOL)
+      set(CTEST_MEMPOOL_ARG "--osh-pool")
+    endif()
+
     string(REPLACE " " ";" VALGRIND "${Omega_h_VALGRIND}")
     if(MPIEXEC_EXECUTABLE)
       set(TEST_STR ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${NUM_PROCS} ${VALGRIND} ${ARGN})
@@ -323,7 +336,7 @@ if(BUILD_TESTING)
         message(STATUS "test ${TEST_NAME} ignored because MPIEXEC_EXECUTABLE not found!")
         return()
       endif()
-      set(TEST_STR ${VALGRIND} ${ARGN})
+      set(TEST_STR ${VALGRIND} ${ARGN} ${CTEST_MEMPOOL_ARG})
     endif()
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_STR})
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
@@ -402,7 +415,7 @@ if(BUILD_TESTING)
 
     osh_add_exe(periodic_test)
     set(TEST_EXES ${TEST_EXES} periodic_test)
-    test_func(periodic_test 2 ./periodic_test 
+    test_func(periodic_test 2 ./periodic_test
       ${CMAKE_SOURCE_DIR}/meshes/wedge_matchZ_12elem.sms
       ${CMAKE_SOURCE_DIR}/meshes/wedge_match.smd
       ${CMAKE_SOURCE_DIR}/meshes/wedge_matchZ_12elem_sync_2.osh 2)
@@ -532,7 +545,7 @@ if(BUILD_TESTING)
   osh_add_exe(refine_scale)
   osh_add_exe(amr_mpi_test)
   osh_add_exe(reverse_class_test)
-  test_func(reverse_class_test 1 ./reverse_class_test 
+  test_func(reverse_class_test 1 ./reverse_class_test
     ${CMAKE_SOURCE_DIR}/meshes/plate_6elem.osh
     ${CMAKE_SOURCE_DIR}/meshes/unitbox_cutTriCube_1k.osh)
   osh_add_exe(rc_field_test)
@@ -546,7 +559,7 @@ if(BUILD_TESTING)
   if(Omega_h_USE_MPI)
     osh_add_exe(reverse_class_testp)
     set(TEST_EXES ${TEST_EXES} reverse_class_testp)
-    test_func(reverse_class_testp 2 ./reverse_class_testp 
+    test_func(reverse_class_testp 2 ./reverse_class_testp
       ${CMAKE_SOURCE_DIR}/meshes/box_3d_2p.osh
       ${CMAKE_SOURCE_DIR}/meshes/unitbox_cutTriCube_1k_2p.osh)
     osh_add_exe(rc_field_testp)

--- a/src/Omega_h_array.cpp
+++ b/src/Omega_h_array.cpp
@@ -28,11 +28,7 @@ T* nonnull(T* p) {
 
 #ifdef OMEGA_H_USE_KOKKOS
 template <typename T>
-Write<T>::Write(Kokkos::View<T*> view_in) : view_(view_in) {
-//  if (is_pooling_enabled()) {
-//    manager_ = KokkosViewWrapper<T>(view_);
-//  }
-}
+Write<T>::Write(Kokkos::View<T*> view_in) : view_(view_in) { }
 #endif
 
 template <typename T>

--- a/src/Omega_h_array.hpp
+++ b/src/Omega_h_array.hpp
@@ -4,8 +4,6 @@
 #include <Omega_h_defines.hpp>
 #include <Omega_h_fail.hpp>
 #include <initializer_list>
-#include <map>
-#include <memory>
 #ifdef OMEGA_H_USE_KOKKOS
 #include <Omega_h_kokkos.hpp>
 #include <Omega_h_pool_kokkos.hpp>
@@ -50,7 +48,7 @@ class KokkosViewWrapper {
 template <typename T>
 class Write {
 #ifdef OMEGA_H_USE_KOKKOS
-  Kokkos::View<T*> view_;                    // is compatible with subview?
+  Kokkos::View<T*> view_;
   SharedRef<KokkosViewWrapper<T>> manager_;  // reference counting
 #else
       SharedAlloc shared_alloc_;

--- a/src/Omega_h_array.hpp
+++ b/src/Omega_h_array.hpp
@@ -4,9 +4,12 @@
 #include <Omega_h_defines.hpp>
 #include <Omega_h_fail.hpp>
 #include <initializer_list>
+#include <map>
 #include <memory>
 #ifdef OMEGA_H_USE_KOKKOS
 #include <Omega_h_kokkos.hpp>
+#include <Omega_h_pool_kokkos.hpp>
+#include <Omega_h_memory.hpp>
 #else
 #include <Omega_h_shared_alloc.hpp>
 #include <string>
@@ -20,25 +23,42 @@ T* nonnull(T* p);
 template <typename T>
 class HostWrite;
 
+#ifdef OMEGA_H_USE_KOKKOS
+template <typename T>
+class KokkosViewWrapper {
+ public:
+  KokkosViewWrapper(size_t n, const std::string& name_in)
+      : view_(KokkosPool::getGlobalPool().allocateView<T>(n)),
+        label_(name_in) {}
+
+  [[nodiscard]] auto label() const -> std::string { return label_; }
+
+  [[nodiscard]] auto getView() const -> const Kokkos::View<T*>& {
+    return view_;
+  }
+
+  ~KokkosViewWrapper() {
+    KokkosPool::getGlobalPool().deallocateView<T>(view_);
+  }
+
+  Kokkos::View<T*> view_;
+  std::string label_;
+};
+
+#endif
+
 template <typename T>
 class Write {
 #ifdef OMEGA_H_USE_KOKKOS
-  Kokkos::View<T*> view_; //is compatible with subview?
+  Kokkos::View<T*> view_;                    // is compatible with subview?
+  SharedRef<KokkosViewWrapper<T>> manager_;  // reference counting
 #else
-  SharedAlloc shared_alloc_;
+      SharedAlloc shared_alloc_;
 #endif
 
  public:
   using value_type = T;
-  OMEGA_H_INLINE Write()
-      :
-#ifdef OMEGA_H_USE_KOKKOS
-        view_()
-#else
-        shared_alloc_()
-#endif
-  {
-  }
+  OMEGA_H_INLINE Write();
 #ifdef OMEGA_H_USE_KOKKOS
   Write(Kokkos::View<T*> view_in);
 #endif
@@ -47,61 +67,20 @@ class Write {
   Write(LO size_in, T offset, T stride, std::string const& name = "");
   Write(std::initializer_list<T> l, std::string const& name = "");
   Write(HostWrite<T> host_write);
-  OMEGA_H_INLINE LO size() const OMEGA_H_NOEXCEPT {
-#ifdef OMEGA_H_CHECK_BOUNDS
-    OMEGA_H_CHECK(exists());
-#endif
-#ifdef OMEGA_H_USE_KOKKOS
-    return static_cast<LO>(view_.size());
-#else
-    return static_cast<LO>(shared_alloc_.size() / sizeof(T));
-#endif
-  }
-  OMEGA_H_DEVICE T& operator[](LO i) const OMEGA_H_NOEXCEPT {
-#ifdef OMEGA_H_CHECK_BOUNDS
-    OMEGA_H_CHECK_OP(0, <=, i);
-    OMEGA_H_CHECK_OP(i, <, size());
-#endif
-#ifdef OMEGA_H_USE_KOKKOS
-    return view_(i);
-#else
-    return data()[i];
-#endif
-  }
-  OMEGA_H_INLINE T* data() const noexcept {
-#ifdef OMEGA_H_USE_KOKKOS
-    return view_.data();
-#else
-    return static_cast<T*>(shared_alloc_.data());
-#endif
-  }
+  OMEGA_H_INLINE LO size() const OMEGA_H_NOEXCEPT;
+  OMEGA_H_DEVICE T& operator[](LO i) const OMEGA_H_NOEXCEPT;
+  OMEGA_H_INLINE T* data() const noexcept;
 #ifdef OMEGA_H_USE_KOKKOS
   OMEGA_H_INLINE Kokkos::View<T*> const& view() const { return view_; }
 #endif
   void set(LO i, T value) const;
   T get(LO i) const;
-#ifdef OMEGA_H_USE_KOKKOS
-  OMEGA_H_INLINE long use_count() const { return view_.use_count(); }
-#else
-  inline int use_count() const { return shared_alloc_.alloc->use_count; }
-#endif
-  OMEGA_H_INLINE bool exists() const noexcept {
-#if defined(OMEGA_H_USE_KOKKOS)
-    return view().data() != nullptr
-#if defined(KOKKOS_ENABLE_DEPRECATED_CODE) && (!defined(__CUDA_ARCH__))
-           /* deprecated Kokkos behavior: zero-span views have data()==nullptr
-            */
-           || view().use_count() != 0
-#endif
-        ;
-#else
-    return shared_alloc_.data() != nullptr;
-#endif
-  }
+  OMEGA_H_INLINE long use_count() const;
+  OMEGA_H_INLINE bool exists() const noexcept;
 #ifdef OMEGA_H_USE_KOKKOS
   std::string name() const;
 #else
-  std::string const& name() const;
+      std::string const& name() const;
 #endif
   OMEGA_H_INLINE T* begin() const noexcept { return data(); }
   OMEGA_H_INLINE T* end() const OMEGA_H_NOEXCEPT { return data() + size(); }
@@ -166,21 +145,7 @@ class HostRead {
   HostRead() = default;
   HostRead(Read<T> read);
   LO size() const;
-  inline T const& operator[](LO i) const OMEGA_H_NOEXCEPT {
-#ifdef OMEGA_H_CHECK_BOUNDS
-    OMEGA_H_CHECK_OP(0, <=, i);
-    OMEGA_H_CHECK_OP(i, <, size());
-#endif
-#ifdef OMEGA_H_USE_KOKKOS
-    return mirror_(i);
-#else
-#ifdef OMEGA_H_USE_CUDA
-    return mirror_.get()[i];
-#else
-    return read_[i];
-#endif
-#endif
-  }
+  inline T const& operator[](LO i) const OMEGA_H_NOEXCEPT;
   T const* data() const;
   T get(LO i) const;
   T last() const;
@@ -203,21 +168,7 @@ class HostWrite {
   HostWrite(std::initializer_list<T> l, std::string const& name = "");
   Write<T> write() const;
   LO size() const OMEGA_H_NOEXCEPT;
-  inline T& operator[](LO i) const OMEGA_H_NOEXCEPT {
-#ifdef OMEGA_H_CHECK_BOUNDS
-    OMEGA_H_CHECK_OP(0, <=, i);
-    OMEGA_H_CHECK_OP(i, <, size());
-#endif
-#ifdef OMEGA_H_USE_KOKKOS
-    return mirror_(i);
-#else
-#ifdef OMEGA_H_USE_CUDA
-    return mirror_.get()[i];
-#else
-    return write_[i];
-#endif
-#endif
-  }
+  inline T& operator[](LO i) const OMEGA_H_NOEXCEPT;
   T* data() const;
   OMEGA_H_INLINE bool exists() const OMEGA_H_NOEXCEPT {
     return write_.exists();
@@ -255,5 +206,11 @@ OMEGA_H_EXPL_INST_DECL(Real)
 /* end explicit instantiation declarations */
 
 }  // end namespace Omega_h
+
+#ifdef OMEGA_H_USE_KOKKOS
+#include "Omega_h_array_kokkos.hpp"
+#else
+#include "Omega_h_array_default.hpp"
+#endif
 
 #endif

--- a/src/Omega_h_array_default.hpp
+++ b/src/Omega_h_array_default.hpp
@@ -1,0 +1,71 @@
+//
+// Created by Matthew McCall on 6/8/23.
+//
+
+#ifndef OMEGA_H_ARRAY_DEFAULT_HPP
+#define OMEGA_H_ARRAY_DEFAULT_HPP
+
+namespace Omega_h {
+
+template <typename T>
+Write<T>::Write() : shared_alloc_() {}
+
+template <typename T>
+LO Write<T>::size() const OMEGA_H_NOEXCEPT {
+#ifdef OMEGA_H_CHECK_BOUNDS
+  OMEGA_H_CHECK(exists());
+#endif
+  return static_cast<LO>(shared_alloc_.size() / sizeof(T));
+}
+
+template <typename T>
+OMEGA_H_DEVICE T& Write<T>::operator[](LO i) const OMEGA_H_NOEXCEPT {
+#ifdef OMEGA_H_CHECK_BOUNDS
+  OMEGA_H_CHECK_OP(0, <=, i);
+  OMEGA_H_CHECK_OP(i, <, size());
+#endif
+  return data()[i];
+}
+
+template <typename T>
+OMEGA_H_INLINE T* Write<T>::data() const noexcept {
+  return static_cast<T*>(shared_alloc_.data());
+}
+
+template <typename T>
+OMEGA_H_INLINE long Write<T>::use_count() const { return shared_alloc_.alloc->use_count; }
+
+template <typename T>
+OMEGA_H_INLINE bool Write<T>::exists() const noexcept {
+  return shared_alloc_.data() != nullptr;
+}
+
+template <typename T>
+inline T const& HostRead<T>::operator[](LO i) const OMEGA_H_NOEXCEPT {
+#ifdef OMEGA_H_CHECK_BOUNDS
+  OMEGA_H_CHECK_OP(0, <=, i);
+  OMEGA_H_CHECK_OP(i, <, size());
+#endif
+#ifdef OMEGA_H_USE_CUDA
+  return mirror_[i];
+#else
+  return read_[i];
+#endif
+}
+
+template <typename T>
+inline T& HostWrite<T>::operator[](LO i) const OMEGA_H_NOEXCEPT {
+#ifdef OMEGA_H_CHECK_BOUNDS
+  OMEGA_H_CHECK_OP(0, <=, i);
+  OMEGA_H_CHECK_OP(i, <, size());
+#endif
+#ifdef OMEGA_H_USE_CUDA
+  return mirror_[i];
+#else
+  return write_[i];
+#endif
+}
+
+} // namespace Omega_h
+
+#endif  // OMEGA_H_ARRAY_DEFAULT_HPP

--- a/src/Omega_h_array_kokkos.hpp
+++ b/src/Omega_h_array_kokkos.hpp
@@ -1,0 +1,75 @@
+//
+// Created by Matthew McCall on 6/8/23.
+//
+
+#ifndef OMEGA_H_ARRAY_KOKKOS_HPP
+#define OMEGA_H_ARRAY_KOKKOS_HPP
+
+namespace Omega_h {
+
+template <typename T>
+OMEGA_H_INLINE Write<T>::Write() : view_() {}
+
+template <typename T>
+OMEGA_H_INLINE LO Write<T>::size() const OMEGA_H_NOEXCEPT {
+#ifdef OMEGA_H_CHECK_BOUNDS
+  OMEGA_H_CHECK(exists());
+#endif
+  return static_cast<LO>(view_.size());
+}
+
+template <typename T>
+OMEGA_H_DEVICE T& Write<T>::operator[](LO i) const OMEGA_H_NOEXCEPT {
+#ifdef OMEGA_H_CHECK_BOUNDS
+  OMEGA_H_CHECK_OP(0, <=, i);
+  OMEGA_H_CHECK_OP(i, <, size());
+#endif
+    return view_(i);
+}
+
+template <typename T>
+OMEGA_H_INLINE T* Write<T>::data() const noexcept {
+    return view_.data();
+}
+
+template <typename T>
+OMEGA_H_INLINE long Write<T>::use_count() const {
+// #if defined(OMEGA_H_COMPILING_FOR_HOST)
+    return manager_ ? manager_.use_count() : view_.use_count();
+// #else
+//    return  view_.use_count();
+// #endif
+}
+
+template <typename T>
+OMEGA_H_INLINE bool Write<T>::exists() const noexcept {
+    return view().data() != nullptr
+#if defined(KOKKOS_ENABLE_DEPRECATED_CODE) && (!defined(__CUDA_ARCH__))
+           /* deprecated Kokkos behavior: zero-span views have data()==nullptr
+            */
+           || view().use_count() != 0
+#endif
+        ;
+}
+
+template <typename T>
+inline T const& HostRead<T>::operator[](LO i) const OMEGA_H_NOEXCEPT {
+#ifdef OMEGA_H_CHECK_BOUNDS
+    OMEGA_H_CHECK_OP(0, <=, i);
+    OMEGA_H_CHECK_OP(i, <, size());
+#endif
+    return mirror_(i);
+}
+
+template <typename T>
+inline T& HostWrite<T>::operator[](LO i) const OMEGA_H_NOEXCEPT {
+#ifdef OMEGA_H_CHECK_BOUNDS
+    OMEGA_H_CHECK_OP(0, <=, i);
+    OMEGA_H_CHECK_OP(i, <, size());
+#endif
+    return mirror_(i);
+}
+
+}  // namespace Omega_h
+
+#endif  // OMEGA_H_ARRAY_KOKKOS_HPP

--- a/src/Omega_h_library.cpp
+++ b/src/Omega_h_library.cpp
@@ -210,6 +210,7 @@ Library::~Library() {
   disable_pooling();
 #ifdef OMEGA_H_USE_KOKKOS
   if (we_called_kokkos_init) {
+    KokkosPool::destroyGlobalPool();
     Kokkos::finalize();
     we_called_kokkos_init = false;
   }

--- a/src/Omega_h_macros.h
+++ b/src/Omega_h_macros.h
@@ -90,4 +90,8 @@
 #define OMEGA_H_DLL
 #endif
 
+#if !defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+#define OMEGA_H_COMPILING_FOR_HOST
+#endif
+
 #endif

--- a/src/Omega_h_macros.h
+++ b/src/Omega_h_macros.h
@@ -90,7 +90,7 @@
 #define OMEGA_H_DLL
 #endif
 
-#if !defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+#if !defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__) && !defined(__SYCL_DEVICE_ONLY__)
 #define OMEGA_H_COMPILING_FOR_HOST
 #endif
 

--- a/src/Omega_h_malloc.cpp
+++ b/src/Omega_h_malloc.cpp
@@ -59,9 +59,12 @@ void host_free(void* ptr, std::size_t) {
 static Pool* device_pool = nullptr;
 static Pool* host_pool = nullptr;
 
+static bool pooling_enabled = false;
+
 void enable_pooling() {
   device_pool = new Pool(device_malloc, device_free);
   host_pool = new Pool(host_malloc, host_free);
+  pooling_enabled = true;
 }
 
 void disable_pooling() {
@@ -69,7 +72,10 @@ void disable_pooling() {
   delete host_pool;
   device_pool = nullptr;
   host_pool = nullptr;
+  pooling_enabled = false;
 }
+
+bool is_pooling_enabled() { return pooling_enabled; }
 
 void* maybe_pooled_device_malloc(std::size_t size) {
   if (device_pool) return allocate(*device_pool, size);

--- a/src/Omega_h_malloc.hpp
+++ b/src/Omega_h_malloc.hpp
@@ -13,6 +13,8 @@ void host_free(void* ptr, std::size_t size);
 void enable_pooling();
 void disable_pooling();
 
+bool is_pooling_enabled();
+
 void* maybe_pooled_device_malloc(std::size_t size);
 void maybe_pooled_device_free(void* ptr, std::size_t size);
 void* maybe_pooled_host_malloc(std::size_t size);

--- a/src/Omega_h_memory.hpp
+++ b/src/Omega_h_memory.hpp
@@ -1,0 +1,176 @@
+#ifndef OMEGA_H_MEMORY_HPP
+#define OMEGA_H_MEMORY_HPP
+
+#include <map>
+
+namespace Omega_h {
+
+template <typename T>
+class SharedRef {
+ public:
+  SharedRef() = default;
+
+  template <typename... Args>
+  explicit SharedRef(Args&&... args)
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+      : ptr_(new T(std::forward<Args>(args)...)) {
+    auto [itr, inserted] = refCount_.insert(std::make_pair(ptr_, 1));
+    assert(inserted);
+  }
+#else
+  {
+  }
+#endif
+
+  OMEGA_H_INLINE SharedRef(const SharedRef& other) {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    if (*this) {
+      decrementRefCount();
+    }
+
+    if (!other) {
+      ptr_ = nullptr;
+      return;
+    }
+
+    ptr_ = other.ptr_;
+    auto itr = refCount_.find(ptr_);
+    assert(itr != refCount_.end());
+    itr->second++;
+#endif
+  }
+
+  OMEGA_H_INLINE SharedRef(SharedRef&& other) noexcept {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    if (*this) {
+      decrementRefCount();
+    }
+
+    if (!other) {
+      ptr_ = nullptr;
+      return;
+    }
+
+    ptr_ = other.ptr_;
+    auto itr = refCount_.find(ptr_);
+    assert(itr != refCount_.end());
+    itr->second++;
+#endif
+  }
+
+  SharedRef& operator=(const SharedRef& other) {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    if (*this) {
+      decrementRefCount();
+    }
+
+    if (!other) {
+      ptr_ = nullptr;
+      return *this;
+    }
+
+    ptr_ = other.ptr_;
+    auto itr = refCount_.find(ptr_);
+    assert(itr != refCount_.end());
+    itr->second++;
+
+#endif
+    return *this;
+  }
+
+  SharedRef& operator=(SharedRef&& other) noexcept {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    if (*this) {
+      decrementRefCount();
+    }
+
+    if (!other) {
+      ptr_ = nullptr;
+      return *this;
+    }
+
+    ptr_ = other.ptr_;
+    auto itr = refCount_.find(ptr_);
+    assert(itr != refCount_.end());
+    itr->second++;
+
+#endif
+    return *this;
+  }
+
+  OMEGA_H_INLINE T* get() const {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    return ptr_;
+#else
+    return nullptr;
+#endif
+  }
+
+  OMEGA_H_INLINE T* operator->() const {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    return ptr_;
+#else
+    return nullptr;
+#endif
+  }
+
+  OMEGA_H_INLINE T& operator*() const {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    return *ptr_;
+#else
+    return nullptr;
+#endif
+  }
+
+  OMEGA_H_INLINE ~SharedRef() {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    if (*this) {
+      decrementRefCount();
+    }
+#endif
+  }
+
+  OMEGA_H_INLINE explicit operator bool() const {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    return ptr_ != nullptr && (refCount_.find(ptr_) != refCount_.end());
+#else
+    return false;
+#endif
+  }
+
+  OMEGA_H_INLINE int use_count() const {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    return *this ? refCount_.find(ptr_)->second : 0;
+#else
+    return 0;
+#endif
+  }
+
+ private:
+  void decrementRefCount() {
+#if defined(OMEGA_H_COMPILING_FOR_HOST)
+    if (!*this) {
+      return;
+    }
+
+    auto itr = refCount_.find(ptr_);
+    assert(itr != refCount_.end());
+    itr->second--;
+    if (itr->second == 0) {
+      refCount_.erase(itr);
+      delete ptr_;
+    }
+#endif
+  }
+
+  T* ptr_ = nullptr;
+
+  static std::map<T*, int> refCount_;
+};
+
+template <typename T>
+std::map<T*, int> SharedRef<T>::refCount_;
+
+}  // namespace Omega_h
+
+#endif  // OMEGA_H_MEMORY_HPP

--- a/src/Omega_h_pool_kokkos.cpp
+++ b/src/Omega_h_pool_kokkos.cpp
@@ -196,7 +196,7 @@ auto KokkosPool::allocate(size_t n) -> void* {
   }
 
   size_t requestedChunks = StaticKokkosPool::getRequiredChunks(n, chunkSize);
-  size_t amortizedChunkSize = std::max(mostAmountOfChunks * 2, requestedChunks);
+  size_t amortizedChunkSize = std::max(mostAmountOfChunks * DEFAULT_GROWTH_CONSTANT, requestedChunks);
 
   try {
     pools.emplace_back(amortizedChunkSize, chunkSize);
@@ -264,10 +264,10 @@ auto KokkosPool::getNumChunks() const -> unsigned {
 }
 
 auto KokkosPool::getGlobalPool() -> KokkosPool& {
-  static Omega_h::KokkosPool s_pool { 1000 };
+  static Omega_h::KokkosPool s_pool { DEFAULT_BYTES_PER_CHUNK };
 
   if (s_pool.getNumChunks() == 0) {
-    s_pool.pools.emplace_back(700'000, s_pool.chunkSize);
+    s_pool.pools.emplace_back(DEFAULT_NUMBER_OF_CHUNKS, s_pool.chunkSize);
   }
 
   return s_pool;
@@ -277,7 +277,7 @@ auto KokkosPool::destroyGlobalPool() -> void {
   auto& s_pool = getGlobalPool();
 
   if (s_pool.getNumAllocations() != 0) {
-    std::cerr << "Warning: Destroying global pool with " << s_pool.getNumAllocations() << " allocations." << std::endl;
+    std::cerr << "Warning: Destroying global pool with " << s_pool.getNumAllocations() << " outstanding allocations." << std::endl;
   }
 
   s_pool.pools.clear();

--- a/src/Omega_h_pool_kokkos.cpp
+++ b/src/Omega_h_pool_kokkos.cpp
@@ -1,0 +1,286 @@
+//
+// Created by Matthew McCall on 6/12/23.
+//
+// Derived from
+// https://github.com/matthew-mccall/kokkos-memory-pool/blob/8e0a45a5b5d6823976d867e20d742314b6a1d268/src/MemoryPool/MemoryPool.cpp
+
+#include "Omega_h_pool_kokkos.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <iterator>
+#include <optional>
+#include <vector>
+
+namespace Omega_h {
+
+auto CompareFreeIndices::operator()(IndexPair lhs, IndexPair rhs) const
+    -> bool {
+  auto [lhsStart, lhsEnd] = lhs;
+  auto [rhsStart, rhsEnd] = rhs;
+  size_t lhsSize = lhsEnd - lhsStart;
+  size_t rhsSize = rhsEnd - rhsStart;
+
+  if (lhsSize == rhsSize) {
+    return lhs < rhs;
+  }
+
+  return lhsSize < rhsSize;
+}
+
+auto CompareFreeIndices::operator()(IndexPair lhs, size_t rhs) const -> bool {
+  auto [lhsStart, lhsEnd] = lhs;
+  return (lhsEnd - lhsStart) < rhs;
+}
+
+auto CompareFreeIndices::operator()(size_t lhs, IndexPair rhs) const -> bool {
+  auto [rhsStart, rhsEnd] = rhs;
+  return lhs < (rhsEnd - rhsStart);
+}
+
+StaticKokkosPool::StaticKokkosPool(size_t numChunks, size_t bytesPerChunks)
+    : numberOfChunks(numChunks)
+    , chunkSize(bytesPerChunks)
+    , pool(Kokkos::kokkos_malloc(numChunks * bytesPerChunks)) {
+  insertIntoSets({0, numChunks});
+}
+
+auto StaticKokkosPool::insertIntoSets(IndexPair indices)
+    -> std::pair<MultiSetBySizeT::iterator, SetByIndexT::iterator> {
+  auto setBySizeItr = freeSetBySize.insert(indices);
+  auto [setByIndexItr, inserted] = freeSetByIndex.insert(indices);
+
+  assert(inserted);
+
+  return {setBySizeItr, setByIndexItr};
+}
+
+void StaticKokkosPool::removeFromSets(IndexPair indices) {
+  freeSetBySize.erase(indices);
+  freeSetByIndex.erase(indices);
+}
+
+auto StaticKokkosPool::allocate(size_t n) -> void* {
+  if (freeSetBySize.empty()) {
+    return nullptr;
+  }
+
+  // Find the smallest sequence of chunks that can hold numElements
+  size_t requestedChunks = getRequiredChunks(n, chunkSize);
+  requestedChunks = std::max(requestedChunks, static_cast<size_t>(1));
+
+  auto freeSetItr = freeSetBySize.lower_bound(requestedChunks);
+  if (freeSetItr == freeSetBySize.end()) {
+    return nullptr;
+  }
+
+  auto [beginIndex, endIndex] = *freeSetItr;
+
+  removeFromSets(*freeSetItr);
+
+  if ((endIndex - beginIndex != requestedChunks)) {
+    insertIntoSets({beginIndex + requestedChunks, endIndex});
+  }
+
+  void* ptr = static_cast<uint8_t*>(pool) + (beginIndex * chunkSize);
+  allocations[ptr] = std::make_pair(beginIndex, beginIndex + requestedChunks);
+
+  return ptr;
+}
+
+void StaticKokkosPool::deallocate(void* data) {
+  auto allocationsItr = allocations.find(data);
+  assert(allocationsItr != allocations.end());
+  auto [ptr, chunkIndices] = *allocationsItr;  // [begin, end)
+
+  auto [freeSetBySizeItr, freeSetByIndexItr] = insertIntoSets(chunkIndices);
+  allocations.erase(allocationsItr);
+
+  // Merge adjacent free chunks
+  if (freeSetByIndexItr != freeSetByIndex.begin()) {
+    auto prevItr = std::prev(freeSetByIndexItr);
+    auto [prevBeginIndex, prevEndIndex] = *prevItr;
+
+    if (prevEndIndex == chunkIndices.first) {
+      removeFromSets(*prevItr);
+      removeFromSets(chunkIndices);
+      freeSetByIndexItr =
+          insertIntoSets({prevBeginIndex, chunkIndices.second}).second;
+    }
+  }
+
+  if (std::next(freeSetByIndexItr) != freeSetByIndex.end()) {
+    auto nextItr = std::next(freeSetByIndexItr);
+    auto [nextBeginIndex, nextEndIndex] = *nextItr;
+    auto [beginIndex, endIndex] = *freeSetByIndexItr;
+
+    if (chunkIndices.second == nextBeginIndex) {
+      removeFromSets(*freeSetByIndexItr);
+      removeFromSets(*nextItr);
+      insertIntoSets({beginIndex, nextEndIndex});
+    }
+  }
+}
+
+auto StaticKokkosPool::getNumAllocations() const -> unsigned {
+  return allocations.size();
+}
+
+auto StaticKokkosPool::getNumFreeChunks() const -> unsigned {
+  unsigned numFreeChunks = 0;
+
+  for (const auto& [beginIndex, endIndex] : freeSetByIndex) {
+    numFreeChunks += endIndex - beginIndex;
+  }
+
+  return numFreeChunks;
+}
+
+auto StaticKokkosPool::getNumAllocatedChunks() const -> unsigned {
+  unsigned numAllocatedChunks = 0;
+
+  for (const auto& [ptr, indices] : allocations) {
+    numAllocatedChunks += indices.second - indices.first;
+  }
+
+  return numAllocatedChunks;
+}
+
+auto StaticKokkosPool::getNumChunks() const -> unsigned {
+  return numberOfChunks;
+}
+
+auto StaticKokkosPool::getNumFreeFragments() const -> unsigned {
+  return freeSetBySize.size();
+}
+
+auto StaticKokkosPool::getRequiredChunks(size_t n, size_t bytesPerChunk)
+    -> size_t {
+  return (n / bytesPerChunk) + (n % bytesPerChunk ? 1 : 0);
+}
+
+StaticKokkosPool::~StaticKokkosPool() {
+  Kokkos::kokkos_free(pool);
+}
+
+auto KokkosPool::getChunkSize() const -> size_t { return chunkSize; }
+
+auto KokkosPool::getNumFreeFragments() const -> unsigned {
+  unsigned numFreeFragments = 0;
+
+  for (const auto& pool : pools) {
+    numFreeFragments += pool.getNumFreeFragments();
+  }
+
+  return numFreeFragments;
+}
+
+KokkosPool::KokkosPool(size_t bytesPerChunks) : chunkSize(bytesPerChunks) {}
+
+auto KokkosPool::allocate(size_t n) -> void* {
+  auto current = pools.begin();
+  size_t mostAmountOfChunks = 0;
+
+  while (current != pools.end()) {
+    void* ptr = current->allocate(n);
+    if (ptr) {
+      allocations[ptr] = current;
+      return ptr;
+    }
+
+    if (current->getNumChunks() > mostAmountOfChunks) {
+      mostAmountOfChunks = current->getNumChunks();
+    }
+
+    current++;
+  }
+
+  size_t requestedChunks = StaticKokkosPool::getRequiredChunks(n, chunkSize);
+  size_t amortizedChunkSize = std::max(mostAmountOfChunks * 2, requestedChunks);
+
+  try {
+    pools.emplace_back(amortizedChunkSize, chunkSize);
+  } catch (const std::runtime_error& e) {
+
+    std::cerr << "Amortization with " << amortizedChunkSize << " chunks failed." << std::endl;
+    std::cerr << e.what() << std::endl;
+
+    if (amortizedChunkSize <= requestedChunks) {
+      throw;
+    }
+
+    pools.emplace_back(requestedChunks, chunkSize);
+  }
+
+  void* ptr = pools.back().allocate(n);
+  assert(ptr != nullptr);
+  allocations[ptr] = std::prev(pools.end());
+
+  return ptr;
+}
+
+void KokkosPool::deallocate(void* data) {
+  try {
+    allocations.at(data)->deallocate(data);
+  } catch (const std::out_of_range& e) {
+    std::cerr << "Attempted to deallocate data that was not allocated by this pool." << std::endl;
+    throw;
+  }
+  allocations.erase(data);
+}
+
+auto KokkosPool::getNumAllocations() const -> unsigned {
+  return allocations.size();
+}
+
+auto KokkosPool::getNumFreeChunks() const -> unsigned {
+  unsigned numFreeChunks = 0;
+
+  for (const auto& pool : pools) {
+    numFreeChunks += pool.getNumFreeChunks();
+  }
+
+  return numFreeChunks;
+}
+
+auto KokkosPool::getNumAllocatedChunks() const -> unsigned {
+  unsigned numAllocatedChunks = 0;
+
+  for (const auto& pool : pools) {
+    numAllocatedChunks += pool.getNumAllocatedChunks();
+  }
+
+  return numAllocatedChunks;
+}
+
+auto KokkosPool::getNumChunks() const -> unsigned {
+  unsigned numChunks = 0;
+
+  for (const auto& pool : pools) {
+    numChunks += pool.getNumChunks();
+  }
+
+  return numChunks;
+}
+
+auto KokkosPool::getGlobalPool() -> KokkosPool& {
+  static Omega_h::KokkosPool s_pool { 1000 };
+
+  if (s_pool.getNumChunks() == 0) {
+    s_pool.pools.emplace_back(700'000, s_pool.chunkSize);
+  }
+
+  return s_pool;
+}
+
+auto KokkosPool::destroyGlobalPool() -> void {
+  auto& s_pool = getGlobalPool();
+
+  if (s_pool.getNumAllocations() != 0) {
+    std::cerr << "Warning: Destroying global pool with " << s_pool.getNumAllocations() << " allocations." << std::endl;
+  }
+
+  s_pool.pools.clear();
+}
+
+}  // namespace Omega_h

--- a/src/Omega_h_pool_kokkos.hpp
+++ b/src/Omega_h_pool_kokkos.hpp
@@ -1,0 +1,114 @@
+//
+// Created by Matthew McCall on 6/12/23.
+//
+// Derived from
+// https://github.com/matthew-mccall/kokkos-memory-pool/blob/8e0a45a5b5d6823976d867e20d742314b6a1d268/src/MemoryPool/MemoryPool.hpp
+
+#ifndef OMEGA_H_KOKKOS_POOL_HPP
+#define OMEGA_H_KOKKOS_POOL_HPP
+
+#include <cstddef>
+#include <list>
+#include <map>
+#include <set>
+#include <utility>
+
+#include "Kokkos_Core.hpp"
+
+namespace Omega_h {
+
+using IndexPair = std::pair<size_t, size_t>;
+
+class CompareFreeIndices {
+ public:
+  using is_transparent =
+      void;  // https://www.fluentcpp.com/2017/06/09/search-set-another-type-key/
+
+  auto operator()(IndexPair lhs, IndexPair rhs) const -> bool;
+  auto operator()(IndexPair lhs, size_t rhs) const -> bool;
+  auto operator()(size_t lhs, IndexPair rhs) const -> bool;
+};
+
+using MultiSetBySizeT = std::multiset<IndexPair, CompareFreeIndices>;
+using SetByIndexT = std::set<IndexPair>;
+
+/**
+ * @brief A memory pool for allocating and deallocating chunks of memory.
+ *
+ * Does not support resizing.
+ */
+class StaticKokkosPool {
+ public:
+  StaticKokkosPool(size_t numChunks, size_t bytesPerChunk);
+
+  auto allocate(size_t n) -> void*;
+  void deallocate(void* data);
+
+  auto getNumAllocations() const -> unsigned;
+  auto getNumFreeChunks() const -> unsigned;
+  auto getNumAllocatedChunks() const -> unsigned;
+  auto getNumChunks() const -> unsigned;
+  auto getNumFreeFragments() const -> unsigned;
+
+  static auto getRequiredChunks(size_t n, size_t bytesPerChunk) -> size_t;
+
+  ~StaticKokkosPool();
+
+ private:
+  auto insertIntoSets(IndexPair indices)
+      -> std::pair<MultiSetBySizeT::iterator, SetByIndexT::iterator>;
+  void removeFromSets(IndexPair indices);
+
+  const size_t numberOfChunks;
+  const size_t chunkSize;
+
+  void* pool;
+  MultiSetBySizeT freeSetBySize;  // For finding free chunks logarithmically
+  SetByIndexT freeSetByIndex;     // For merging adjacent free chunks
+  std::map<void*, IndexPair> allocations;
+};
+
+/**
+ * @brief A memory pool for allocating and deallocating chunks of memory.
+ *
+ * It is a collection of StaticKokkosPool objects. This allows for resizing.
+ */
+class KokkosPool {
+ public:
+  explicit KokkosPool(size_t bytesPerChunks);
+
+  auto allocate(size_t n) -> void*;
+  void deallocate(void* data);
+
+  template <typename DataType>
+  auto allocateView(size_t n) -> Kokkos::View<DataType*> {
+    return Kokkos::View<DataType*>(
+        reinterpret_cast<DataType*>(allocate(n * sizeof(DataType))), n);
+  }
+
+  template <typename DataType>
+  void deallocateView(Kokkos::View<DataType*> view) {
+    deallocate(reinterpret_cast<void*>(view.data()));
+  }
+
+  auto getNumAllocations() const -> unsigned;
+  auto getNumFreeChunks() const -> unsigned;
+  auto getNumAllocatedChunks() const -> unsigned;
+  auto getNumChunks() const -> unsigned;
+  auto getNumFreeFragments() const -> unsigned;
+  auto getChunkSize() const -> size_t;
+
+  static auto getGlobalPool() -> KokkosPool&;
+  static auto destroyGlobalPool() -> void;
+
+ private:
+  using PoolListT = std::list<StaticKokkosPool>;
+
+  size_t chunkSize;
+  PoolListT pools;
+  std::map<void*, PoolListT::iterator> allocations;
+};
+
+}  // namespace Omega_h
+
+#endif  // OMEGA_H_KOKKOS_POOL_HPP

--- a/src/Omega_h_pool_kokkos.hpp
+++ b/src/Omega_h_pool_kokkos.hpp
@@ -17,6 +17,14 @@
 
 namespace Omega_h {
 
+constexpr size_t DEFAULT_BYTES_PER_CHUNK = 1000;
+
+// Total initial size in bytes will subsequently be DEFAULT_NUMBER_OF_CHUNKS * DEFAULT_BYTES_PER_CHUNK
+constexpr size_t DEFAULT_NUMBER_OF_CHUNKS = 700'000;
+
+// If the largest StaticKokkosPool is 2Kb, then the next StaticKokkosPool will be at least 4kB resulting in a total pool size of 2Kb + 4Kb = 6Kb
+constexpr size_t DEFAULT_GROWTH_CONSTANT = 2;
+
 using IndexPair = std::pair<size_t, size_t>;
 
 class CompareFreeIndices {


### PR DESCRIPTION
This adds a memory pool for Kokkos. It is integrated into `Write<T>` and can is enabled with the `--osh-pool` flag. From there, you can construct and use `Write` objects as you normally would, with the flag enabled, sufficient memory is automatically allocated from the pool. The pool is lazy initialized to ensure the memory is only allocated after Omega_h finished initialization and `Kokkos::initialize` has been called. Allocation time is `O(n*log(n))` but can be tuned to achieve `O(log(n))` in most cases. Deallocation time is `O(log(n))` 

### Implementation Details
On the first `Write` allocated, the `Write` constructor attempts to get the static global pool. To support resizing the pool without invalidating existing allocations, the global `KokkosPool` is comprised of multiple `KokkosStaticPool`s which have a fixed size. Lazy initialization is achieved by deferring the creation of the first `KokkosStaticPool` until the first call to `KokkosPool::allocate`. On each allocation, the `KokkosPool` iterates over available `StaticKokkosPools` and tries to allocate from each pool until it gets a valid pointer to memory. Each `StaticKokkosPools` divides the memory into contiguous chunks. It stores the indices of free contiguous sections of chunks in a `std::multiset` achieving logarithmic allocation time for each individual `StaticKokkosPool`. A logarithmic search over the `multiset` is performed to find the smallest possible index range to accommodate the size requested. If a suitable range is found, the minimum amount of chunks is taken from that fragment and then returned; the `multiset` is updated accordingly. If no suitable fragment is found, then `nullptr` is returned. This forces `KokkosPool` to move to the next `StaticKokkosPool` and try allocation again. If none of the existing `StaticKokkosPool`s are able to allocate the requested memory, then `KokkosPool` creates a new `StaticKokkosPool` whose size is the greater of twice the size of the largest `StaticKokkosPool` or the size of the allocation requested. The memory is then allocated from that new pool.

`KokkosPool` provides the convenience functions `KokkosPool::allocateView<T>` and `KokkosPool::deallocateView<T>`. This allocates and returned typed views of the size requested. Unfortunately, Kokkos does not reference count these views. As such, a custom `SharedRef<T>` class was implemented inspired by `std::shared_ptr`. This is a general implementation of a `shared_ptr` and is not specific to `Write` or `Kokkos::View`. Note: This implementation only exists as `std::shared_ptr` will not compile with `nvcc` or `hipcc` when compiling in a device context. Furthermore, no memory is being allocated while in a device context. It exists so that the implementation details are only defined in a host context.