### PR TITLE
Device Space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,13 +106,18 @@ if(Omega_h_USE_Kokkos)
   endif()
 endif()
 
-string(TOUPPER "${Omega_h_USE_KOKKOS_MEM_SPACE}" Omega_h_USE_KOKKOS_MEM_SPACE)
-if (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "DEVICE")
-  bob_option(Omega_h_MEM_SPACE_DEVICE "Whether to use GPU memory space" "ON")
-elseif (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "SHARED")
-  bob_option(Omega_h_MEM_SPACE_SHARED "Whether to use shared memory space" "ON")
-elseif (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "HOSTPINNED")
-  bob_option(Omega_h_MEM_SPACE_HOSTPINNED "Whether to use host pinned memory space" "ON")
+bob_option(Omega_h_MEM_SPACE_SHARED "Whether to use shared memory space" OFF)
+bob_option(Omega_h_MEM_SPACE_HOSTPINNED "Whether to use host pinned memory space" OFF)
+if ((Omega_h_USE_CUDA OR Omega_h_USE_HIP OR Omega_h_USE_SYCL) AND NOT (Omega_h_MEM_SPACE_SHARED OR Omega_h_MEM_SPACE_HOSTPINNED))
+  bob_option(Omega_h_MEM_SPACE_DEVICE "Whether to use GPU memory space" ON)
+else()
+  bob_option(Omega_h_MEM_SPACE_DEVICE "Whether to use GPU memory space" OFF)
+endif()
+
+if ((Omega_h_MEM_SPACE_DEVICE AND Omega_h_MEM_SPACE_HOSTPINNED) OR 
+    (Omega_h_MEM_SPACE_DEVICE AND Omega_h_MEM_SPACE_SHARED) OR 
+    (Omega_h_MEM_SPACE_SHARED AND Omega_h_MEM_SPACE_HOSTPINNED))
+  message(FATAL_ERROR "Only one memory space allowed from these options: [ Omega_h_MEM_SPACE_SHARED, Omega_h_MEM_SPACE_HOSTPINNED, Omega_h_MEM_SPACE_DEVICE ]")
 endif()
 
 bob_option(Omega_h_USE_MPI "Use MPI for parallelism" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if(Omega_h_USE_Kokkos)
   if ("HIP" IN_LIST Kokkos_DEVICES)
     add_definitions(-DOmega_h_USE_HIP)
     bob_option(Omega_h_USE_HIP "Whether to use HIP" "ON")
-    endif()
+  endif()
   if (Omega_h_USE_CUDA AND (NOT "CUDA_LAMBDA" IN_LIST Kokkos_OPTIONS))
     message(FATAL_ERROR
             "Please reconfigure Kokkos with -DKokkos_ENABLE_Cuda_Lambda:BOOL=ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,10 @@ endif()
 
 if (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "DEVICE")
   add_definitions(-DOmega_h_MEM_SPACE_DEVICE)
+elseif (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "SHARED")
+  add_definitions(-DOmega_h_MEM_SPACE_SHARED)
+elseif (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "HOSTPINNED")
+  add_definitions(-DOmega_h_MEM_SPACE_HOSTPINNED)
 endif()
 
 bob_option(Omega_h_USE_MPI "Use MPI for parallelism" OFF)
@@ -150,7 +154,6 @@ set(Omega_h_KEY_BOOLS
     Omega_h_USE_CUDA
     Omega_h_USE_SYCL
     Omega_h_USE_HIP
-    Omega_h_MEM_SPACE_DEVICE
     Omega_h_USE_ZLIB
     Omega_h_USE_libMeshb
     Omega_h_USE_EGADS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,21 +89,29 @@ bob_public_dep(pybind11)
 
 if(Omega_h_USE_Kokkos)
   if ("CUDA" IN_LIST Kokkos_DEVICES)
+      add_definitions(-DOmega_h_USE_CUDA)
       bob_option(Omega_h_USE_CUDA "Whether to use CUDA" "ON")
   endif()
   if ("OPENMP" IN_LIST Kokkos_DEVICES)
+      add_definitions(-DOmega_h_USE_OpenMP)
       bob_option(Omega_h_USE_OpenMP "Whether to use OpenMP" "ON")
   endif()
   if ("SYCL" IN_LIST Kokkos_DEVICES)
+      add_definitions(-DOmega_h_USE_SYCL)
       bob_option(Omega_h_USE_SYCL "Whether to use SYCL" "ON")
   endif()
   if ("HIP" IN_LIST Kokkos_DEVICES)
+    add_definitions(-DOmega_h_USE_HIP)
     bob_option(Omega_h_USE_HIP "Whether to use HIP" "ON")
-  endif()
+    endif()
   if (Omega_h_USE_CUDA AND (NOT "CUDA_LAMBDA" IN_LIST Kokkos_OPTIONS))
     message(FATAL_ERROR
             "Please reconfigure Kokkos with -DKokkos_ENABLE_Cuda_Lambda:BOOL=ON")
   endif()
+endif()
+
+if (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "DEVICE")
+  add_definitions(-DOmega_h_MEM_SPACE_DEVICE)
 endif()
 
 bob_option(Omega_h_USE_MPI "Use MPI for parallelism" OFF)
@@ -142,6 +150,7 @@ set(Omega_h_KEY_BOOLS
     Omega_h_USE_CUDA
     Omega_h_USE_SYCL
     Omega_h_USE_HIP
+    Omega_h_MEM_SPACE_DEVICE
     Omega_h_USE_ZLIB
     Omega_h_USE_libMeshb
     Omega_h_USE_EGADS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,19 +89,15 @@ bob_public_dep(pybind11)
 
 if(Omega_h_USE_Kokkos)
   if ("CUDA" IN_LIST Kokkos_DEVICES)
-      add_definitions(-DOmega_h_USE_CUDA)
       bob_option(Omega_h_USE_CUDA "Whether to use CUDA" "ON")
   endif()
   if ("OPENMP" IN_LIST Kokkos_DEVICES)
-      add_definitions(-DOmega_h_USE_OpenMP)
       bob_option(Omega_h_USE_OpenMP "Whether to use OpenMP" "ON")
   endif()
   if ("SYCL" IN_LIST Kokkos_DEVICES)
-      add_definitions(-DOmega_h_USE_SYCL)
       bob_option(Omega_h_USE_SYCL "Whether to use SYCL" "ON")
   endif()
   if ("HIP" IN_LIST Kokkos_DEVICES)
-    add_definitions(-DOmega_h_USE_HIP)
     bob_option(Omega_h_USE_HIP "Whether to use HIP" "ON")
   endif()
   if (Omega_h_USE_CUDA AND (NOT "CUDA_LAMBDA" IN_LIST Kokkos_OPTIONS))
@@ -110,12 +106,13 @@ if(Omega_h_USE_Kokkos)
   endif()
 endif()
 
+string(TOUPPER "${Omega_h_USE_KOKKOS_MEM_SPACE}" Omega_h_USE_KOKKOS_MEM_SPACE)
 if (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "DEVICE")
-  add_definitions(-DOmega_h_MEM_SPACE_DEVICE)
+  bob_option(Omega_h_MEM_SPACE_DEVICE "Whether to use GPU memory space" "ON")
 elseif (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "SHARED")
-  add_definitions(-DOmega_h_MEM_SPACE_SHARED)
+  bob_option(Omega_h_MEM_SPACE_SHARED "Whether to use shared memory space" "ON")
 elseif (Omega_h_USE_KOKKOS_MEM_SPACE STREQUAL "HOSTPINNED")
-  add_definitions(-DOmega_h_MEM_SPACE_HOSTPINNED)
+  bob_option(Omega_h_MEM_SPACE_HOSTPINNED "Whether to use host pinned memory space" "ON")
 endif()
 
 bob_option(Omega_h_USE_MPI "Use MPI for parallelism" OFF)
@@ -154,6 +151,9 @@ set(Omega_h_KEY_BOOLS
     Omega_h_USE_CUDA
     Omega_h_USE_SYCL
     Omega_h_USE_HIP
+    Omega_h_MEM_SPACE_DEVICE
+    Omega_h_MEM_SPACE_SHARED
+    Omega_h_MEM_SPACE_HOSTPINNED
     Omega_h_USE_ZLIB
     Omega_h_USE_libMeshb
     Omega_h_USE_EGADS

--- a/src/Omega_h_array.cpp
+++ b/src/Omega_h_array.cpp
@@ -28,7 +28,7 @@ T* nonnull(T* p) {
 
 #ifdef OMEGA_H_USE_KOKKOS
 template <typename T>
-Write<T>::Write(Kokkos::View<T*> view_in) : view_(view_in) { }
+Write<T>::Write(View<T*> view_in) : view_(view_in) { }
 #endif
 
 template <typename T>
@@ -150,8 +150,8 @@ Read<T>::Read(std::initializer_list<T> l, std::string const& name_in)
 
 #ifdef OMEGA_H_USE_KOKKOS
 template <typename T>
-Kokkos::View<const T*> Read<T>::view() const {
-  return Kokkos::View<const T*>(write_.view());
+View<const T*> Read<T>::view() const {
+  return View<const T*>(write_.view());
 }
 #endif
 
@@ -310,7 +310,7 @@ template <typename T>
 HostRead<T>::HostRead(Read<T> read) : read_(read) {
   ScopedTimer timer("array device to host");
 #ifdef OMEGA_H_USE_KOKKOS
-  Kokkos::View<const T*> dev_view = read.view();
+  View<const T*> dev_view = read.view();
   Kokkos::View<const T*, Kokkos::HostSpace> h_view =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), read.view());
   mirror_ = h_view;

--- a/src/Omega_h_array.hpp
+++ b/src/Omega_h_array.hpp
@@ -31,7 +31,7 @@ class KokkosViewWrapper {
 
   [[nodiscard]] auto label() const -> std::string { return label_; }
 
-  [[nodiscard]] auto getView() const -> const Kokkos::View<T*>& {
+  [[nodiscard]] auto getView() const -> const View<T*>& {
     return view_;
   }
 
@@ -39,7 +39,7 @@ class KokkosViewWrapper {
     KokkosPool::getGlobalPool().deallocateView<T>(view_);
   }
 
-  Kokkos::View<T*> view_;
+  View<T*> view_;
   std::string label_;
 };
 
@@ -48,7 +48,7 @@ class KokkosViewWrapper {
 template <typename T>
 class Write {
 #ifdef OMEGA_H_USE_KOKKOS
-  Kokkos::View<T*> view_;
+  View<T*> view_;
   SharedRef<KokkosViewWrapper<T>> manager_;  // reference counting
 #else
       SharedAlloc shared_alloc_;
@@ -58,7 +58,7 @@ class Write {
   using value_type = T;
   OMEGA_H_INLINE Write();
 #ifdef OMEGA_H_USE_KOKKOS
-  Write(Kokkos::View<T*> view_in);
+  Write(View<T*> view_in);
 #endif
   Write(LO size_in, std::string const& name = "");
   Write(LO size_in, T value, std::string const& name = "");
@@ -69,7 +69,7 @@ class Write {
   OMEGA_H_DEVICE T& operator[](LO i) const OMEGA_H_NOEXCEPT;
   OMEGA_H_INLINE T* data() const noexcept;
 #ifdef OMEGA_H_USE_KOKKOS
-  OMEGA_H_INLINE Kokkos::View<T*> const& view() const { return view_; }
+  OMEGA_H_INLINE View<T*> const& view() const { return view_; }
 #endif
   void set(LO i, T value) const;
   T get(LO i) const;
@@ -107,7 +107,7 @@ class Read {
     return write_.data();
   }
 #ifdef OMEGA_H_USE_KOKKOS
-  Kokkos::View<const T*> view() const;
+  View<const T*> view() const;
 #endif
   T get(LO i) const;
   T first() const;
@@ -153,7 +153,7 @@ template <typename T>
 class HostWrite {
   Write<T> write_;
 #ifdef OMEGA_H_USE_KOKKOS
-  typename Kokkos::View<T*>::HostMirror mirror_;
+  typename View<T*>::HostMirror mirror_;
 #elif defined(OMEGA_H_USE_CUDA)
   std::shared_ptr<T> mirror_;
 #endif

--- a/src/Omega_h_array_ops.cpp
+++ b/src/Omega_h_array_ops.cpp
@@ -44,7 +44,7 @@ template <typename T>
 bool operator==(Read<T> a, Read<T> b) {
   OMEGA_H_CHECK(a.size() == b.size());
 #if defined(OMEGA_H_USE_KOKKOS)
-  Kokkos::View<const T*> nonConstB = b.view();
+  View<const T*> nonConstB = b.view();
   return Kokkos::Experimental::equal("array_equal",ExecSpace(), a.view(), nonConstB);
 #else
   auto const first = IntIterator(0);

--- a/src/Omega_h_kokkos.hpp
+++ b/src/Omega_h_kokkos.hpp
@@ -51,8 +51,14 @@ namespace Omega_h {
     using Space = Kokkos::Experimental::SYCLDeviceUSMSpace;
   #endif
 #elif defined(OMEGA_H_MEM_SPACE_SHARED)
+  #if !defined(KOKKOS_HAS_SHARED_SPACE)
+    #error Shared memory space in unavailable
+  #endif
   using Space = Kokkos::SharedSpace;
 #elif defined(OMEGA_H_MEM_SPACE_HOSTPINNED)
+  #if !defined(KOKKOS_HAS_SHARED_HOST_PINNED_SPACE)
+    #error Host Pinned memory space in unavailable
+  #endif
   using Space = Kokkos::SharedHostPinnedSpace;
 #else
   using Space = ExecSpace::memory_space;

--- a/src/Omega_h_kokkos.hpp
+++ b/src/Omega_h_kokkos.hpp
@@ -29,8 +29,29 @@ OMEGA_H_SYSTEM_HEADER
 #endif
 
 namespace Omega_h {
-using Space = Kokkos::CudaSpace;
-using ExecSpace = Kokkos::Cuda;
+
+#if defined(Omega_h_USE_CUDA)
+  using ExecSpace = Kokkos::Cuda;
+#elif defined(Omega_h_USE_HIP)
+  using ExecSpace = Kokkos::HIP;
+#elif defined(Omega_h_USE_SYCL)
+  using ExecSpace = Kokkos::Experimental::SYCL;
+#elif defined(Omega_h_USE_OpenMP)
+  using ExecSpace = Kokkos::OpenMP;
+#else
+  using ExecSpace = Kokkos::DefaultExecutionSpace;
+#endif
+
+#if defined(Omega_h_MEM_SPACE_DEVICE)
+  #if defined(Omega_h_USE_CUDA)
+    using Space = Kokkos::CudaSpace;
+  #elif defined(Omega_h_USE_HIP)
+    using Space = Kokkos::HIPSpace;
+  #endif
+#else
+  using Space = ExecSpace::memory_space;
+#endif
+
 using StaticSched = Kokkos::Schedule<Kokkos::Static>;
 using Policy = Kokkos::RangePolicy<ExecSpace, StaticSched, Omega_h::LO>;
 

--- a/src/Omega_h_kokkos.hpp
+++ b/src/Omega_h_kokkos.hpp
@@ -29,9 +29,12 @@ OMEGA_H_SYSTEM_HEADER
 #endif
 
 namespace Omega_h {
-using ExecSpace = Kokkos::DefaultExecutionSpace;
+using Space = Kokkos::CudaSpace;
+using ExecSpace = Kokkos::Cuda;
 using StaticSched = Kokkos::Schedule<Kokkos::Static>;
 using Policy = Kokkos::RangePolicy<ExecSpace, StaticSched, Omega_h::LO>;
+
+template <class T> using View = Kokkos::View<T, Space>;
 
 inline Policy policy(LO n) { return Policy(0, n); }
 }  // namespace Omega_h

--- a/src/Omega_h_kokkos.hpp
+++ b/src/Omega_h_kokkos.hpp
@@ -30,29 +30,29 @@ OMEGA_H_SYSTEM_HEADER
 
 namespace Omega_h {
 
-#if defined(Omega_h_USE_CUDA)
+#if defined(OMEGA_H_USE_CUDA)
   using ExecSpace = Kokkos::Cuda;
-#elif defined(Omega_h_USE_HIP)
+#elif defined(OMEGA_H_USE_HIP)
   using ExecSpace = Kokkos::HIP;
-#elif defined(Omega_h_USE_SYCL)
+#elif defined(OMEGA_H_USE_SYCL)
   using ExecSpace = Kokkos::Experimental::SYCL;
-#elif defined(Omega_h_USE_OpenMP)
+#elif defined(OMEGA_H_USE_OpenMP)
   using ExecSpace = Kokkos::OpenMP;
 #else
   using ExecSpace = Kokkos::DefaultExecutionSpace;
 #endif
 
-#if defined(Omega_h_MEM_SPACE_DEVICE)
-  #if defined(Omega_h_USE_CUDA)
+#if defined(OMEGA_H_MEM_SPACE_DEVICE)
+  #if defined(OMEGA_H_USE_CUDA)
     using Space = Kokkos::CudaSpace;
-  #elif defined(Omega_h_USE_HIP)
+  #elif defined(OMEGA_H_USE_HIP)
     using Space = Kokkos::HIPSpace;
-  #elif defined(Omega_h_USE_SYCL)
+  #elif defined(OMEGA_H_USE_SYCL)
     using Space = Kokkos::Experimental::SYCLDeviceUSMSpace;
   #endif
-#elif defined(Omega_h_MEM_SPACE_SHARED)
+#elif defined(OMEGA_H_MEM_SPACE_SHARED)
   using Space = Kokkos::SharedSpace;
-#elif defined(Omega_h_MEM_SPACE_HOSTPINNED)
+#elif defined(OMEGA_H_MEM_SPACE_HOSTPINNED)
   using Space = Kokkos::SharedHostPinnedSpace;
 #else
   using Space = ExecSpace::memory_space;

--- a/src/Omega_h_kokkos.hpp
+++ b/src/Omega_h_kokkos.hpp
@@ -47,15 +47,22 @@ namespace Omega_h {
     using Space = Kokkos::CudaSpace;
   #elif defined(Omega_h_USE_HIP)
     using Space = Kokkos::HIPSpace;
+  #elif defined(Omega_h_USE_SYCL)
+    using Space = Kokkos::Experimental::SYCLDeviceUSMSpace;
   #endif
+#elif defined(Omega_h_MEM_SPACE_SHARED)
+  using Space = Kokkos::SharedSpace;
+#elif defined(Omega_h_MEM_SPACE_HOSTPINNED)
+  using Space = Kokkos::SharedHostPinnedSpace;
 #else
   using Space = ExecSpace::memory_space;
 #endif
 
+using Device = Kokkos::Device<ExecSpace, Space>;
 using StaticSched = Kokkos::Schedule<Kokkos::Static>;
 using Policy = Kokkos::RangePolicy<ExecSpace, StaticSched, Omega_h::LO>;
 
-template <class T> using View = Kokkos::View<T, Space>;
+template <class T> using View = Kokkos::View<T, Device>;
 
 inline Policy policy(LO n) { return Policy(0, n); }
 }  // namespace Omega_h

--- a/src/Omega_h_pool_kokkos.hpp
+++ b/src/Omega_h_pool_kokkos.hpp
@@ -14,6 +14,7 @@
 #include <utility>
 
 #include "Kokkos_Core.hpp"
+#include "Omega_h_kokkos.hpp"
 
 namespace Omega_h {
 
@@ -89,13 +90,13 @@ class KokkosPool {
   void deallocate(void* data);
 
   template <typename DataType>
-  auto allocateView(size_t n) -> Kokkos::View<DataType*> {
-    return Kokkos::View<DataType*>(
+  auto allocateView(size_t n) -> View<DataType*> {
+    return View<DataType*>(
         reinterpret_cast<DataType*>(allocate(n * sizeof(DataType))), n);
   }
 
   template <typename DataType>
-  void deallocateView(Kokkos::View<DataType*> view) {
+  void deallocateView(View<DataType*> view) {
     deallocate(reinterpret_cast<void*>(view.data()));
   }
 

--- a/src/unit_array_algs.cpp
+++ b/src/unit_array_algs.cpp
@@ -350,15 +350,15 @@ static void test_expr2() {
 
 static void test_array_from_kokkos() {
 #ifdef OMEGA_H_USE_KOKKOS
-  Kokkos::View<double**> managed(
+  View<double**> managed(
       Kokkos::ViewAllocateWithoutInitializing("view"), 10, 10);
-  Kokkos::View<double*> unmanaged(managed.data(), managed.span());
+  View<double*> unmanaged(managed.data(), managed.span());
   Omega_h::Write<double> unmanaged_array(unmanaged);
   OMEGA_H_CHECK(unmanaged_array.exists());
-  Kokkos::View<double*> zero_span("zero_span", 0);
+  View<double*> zero_span("zero_span", 0);
   Omega_h::Write<double> zero_span_array(zero_span);
   OMEGA_H_CHECK(zero_span_array.exists());
-  Kokkos::View<double*> uninitialized;
+  View<double*> uninitialized;
   Omega_h::Write<double> uninitialized_array(uninitialized);
   OMEGA_H_CHECK(!uninitialized_array.exists());
 #endif


### PR DESCRIPTION
This branch adds a cmake option that will choose the memory Omega_h will use:
Omega_h_MEM_SPACE_[DEVICE|SHARED|HOSTPINNED] = ON

It will return a cmake error if more than one is used and a compile error if it is unavailable.

It will also decide which execution space to use based on what is available in Kokkos