### PR TITLE
Fix Kokkos Memory Pool when using Shared Memory Spaces

### DIFF
--- a/src/Omega_h_for.hpp
+++ b/src/Omega_h_for.hpp
@@ -93,7 +93,10 @@ void parallel_for(LO n, UnaryFunction&& f) {
 template <typename T>
 void parallel_for(LO n, T const& f, char const* name = "") {
 #if defined(OMEGA_H_USE_KOKKOS)
-  if (n > 0) Kokkos::parallel_for(name, policy(n), f);
+  if (n > 0) {
+    Kokkos::parallel_for(name, policy(n), f);
+    Kokkos::fence();
+  }
 #else
   (void)name;
   auto const first = IntIterator(0);

--- a/src/Omega_h_pool_kokkos.cpp
+++ b/src/Omega_h_pool_kokkos.cpp
@@ -41,7 +41,11 @@ auto CompareFreeIndices::operator()(size_t lhs, IndexPair rhs) const -> bool {
 StaticKokkosPool::StaticKokkosPool(size_t numChunks, size_t bytesPerChunks)
     : numberOfChunks(numChunks)
     , chunkSize(bytesPerChunks)
+#if defined(OMEGA_H_MEM_SPACE_SHARED)
+    , pool(Kokkos::kokkos_malloc<Kokkos::SharedSpace>(numChunks * bytesPerChunks)) {
+#else
     , pool(Kokkos::kokkos_malloc(numChunks * bytesPerChunks)) {
+#endif
   insertIntoSets({0, numChunks});
 }
 
@@ -160,7 +164,11 @@ auto StaticKokkosPool::getRequiredChunks(size_t n, size_t bytesPerChunk)
 }
 
 StaticKokkosPool::~StaticKokkosPool() {
+#if defined(OMEGA_H_MEM_SPACE_SHARED)
+  Kokkos::kokkos_free<Kokkos::SharedSpace>(pool);
+#else
   Kokkos::kokkos_free(pool);
+#endif
 }
 
 auto KokkosPool::getChunkSize() const -> size_t { return chunkSize; }


### PR DESCRIPTION
This pull request fixes an issue that causes a segmentation fault when using the memory pool for the Kokkos backend. Specifically, `kokkos_malloc` and `kokkos_free` normally allocate/free from the default memory space unless that memory space is `SharedSpace`. As such, `SharedSpace` must be explicitly passed as a template parameter to `kokkos_malloc` and `kokkos_free` when using shared memory spaces.

While this rectifies the problem for most tests, `run_unit_mesh` seems to fail (for a different reason this time). It appears some fencing needs to be done after `Kokkos::parallel_for` since lack of which caused an error to be thrown later in the test.
