### PR TITLE
Allow adding global tags to a mesh object

### DIFF
--- a/src/Omega_h_mesh.cpp
+++ b/src/Omega_h_mesh.cpp
@@ -1482,4 +1482,18 @@ OMEGA_H_INST(I64)
 OMEGA_H_INST(Real)
 #undef OMEGA_H_INST
 
+#define OMEGA_H_GLOBAL_TAGS_EXPL_INST(T)                                           \
+template T const& Mesh::get_global_tag<T>(std::string const& name)const;         \
+template void Mesh::add_global_tag<T>(std::string const& name, T const& value);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST(I8);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST(I32);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST(I64);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST(Real);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST(std::string);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST(std::vector<I32>);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST(std::vector<I64>);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST(std::vector<Real>);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST(std::vector<std::string>);
+#undef OMEGA_H_GLOBAL_TAGS_EXPL_INST
+
 }  // end namespace Omega_h

--- a/src/Omega_h_mesh.cpp
+++ b/src/Omega_h_mesh.cpp
@@ -352,14 +352,15 @@ const T& Mesh::get_global_tag(std::string const& name) const
   auto it = global_tags_.find(name);
   OMEGA_H_CHECK (it!=global_tags_.end());
 
-  try {
-    return std::any_cast<T>(it->second);
-  } catch (const std::bad_any_cast&) {
-    printf("Attempt to access global tag %s with the wrong type\n",name.c_str());
-    printf("  typeid of requested type: %s\n",typeid(T).name());
-    printf("  typeid of stored ojbect : %s\n",it->second.type().name());
-    throw;
+  const T* p = std::any_cast<T>(&it->second);
+  if (p==nullptr) {
+    std::string s;
+    s += "Attempt to access global tag " + name + " with the wrong type\n";
+    s += "  typeid of requested type: " + std::string(typeid(T).name()) + "\n";
+    s += "  typeid of stored ojbect : " + std::string(it->second.type().name()) + "\n";
+    throw std::runtime_error(s);
   }
+  return *p;
 }
 
 TagBase const* Mesh::get_tagbase(Int ent_dim, std::string const& name) const {

--- a/src/Omega_h_mesh.cpp
+++ b/src/Omega_h_mesh.cpp
@@ -219,6 +219,11 @@ GO Mesh::nglobal_ents(Int ent_dim) {
 }
 
 template <typename T>
+void Mesh::add_global_tag(std::string const& name, const T& value) {
+  global_tags_[name] = std::any(value);
+}
+
+template <typename T>
 void Mesh::add_tag(Int ent_dim, std::string const& name, Int ncomps) {
   this->add_tag(ent_dim, name, ncomps, Read<T>(), true);
 }
@@ -338,6 +343,22 @@ void Mesh::react_to_set_tag(Topo_type ent_type, std::string const& name) {
     remove_tag(Topo_type::tetrahedron, "size");
     remove_tag(Topo_type::quadrilateral, "size");
     remove_tag(Topo_type::triangle, "size");
+  }
+}
+
+template <typename T>
+const T& Mesh::get_global_tag(std::string const& name) const
+{
+  auto it = global_tags_.find(name);
+  OMEGA_H_CHECK (it!=global_tags_.end());
+
+  try {
+    return std::any_cast<T>(it->second);
+  } catch (const std::bad_any_cast&) {
+    printf("Attempt to access global tag %s with the wrong type\n",name.c_str());
+    printf("  typeid of requested type: %s\n",typeid(T).name());
+    printf("  typeid of stored ojbect : %s\n",it->second.type().name());
+    throw;
   }
 }
 

--- a/src/Omega_h_mesh.hpp
+++ b/src/Omega_h_mesh.hpp
@@ -11,6 +11,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <any>
 
 namespace Omega_h {
 
@@ -77,6 +78,8 @@ class Mesh {
 
   GO nglobal_ents(Int dim);
   template <typename T>
+  void add_global_tag(std::string const& name, const T& value);
+  template <typename T>
   void add_tag(Int dim, std::string const& name, Int ncomps);
   template <typename T>
   void add_tag(Topo_type ent_type, std::string const& name, Int ncomps);
@@ -94,6 +97,8 @@ class Mesh {
       bool internal = false);
   TagBase const* get_tagbase(Int dim, std::string const& name) const;
   TagBase const* get_tagbase(Topo_type ent_type, std::string const& name) const;
+  template <typename T>
+  const T& get_global_tag(std::string const& name) const;
   template <typename T>
   Tag<T> const* get_tag(Int dim, std::string const& name) const;
   template <typename T>
@@ -282,6 +287,7 @@ class Mesh {
   Int nghost_layers_;
   LO nents_[DIMS];
   LO nents_type_[TOPO_TYPES];
+  std::map<std::string,std::any> global_tags_;
   TagVector tags_[DIMS];
   TagVector tags_type_[TOPO_TYPES];
   // rc field tags stored in "rc" format

--- a/src/Omega_h_mesh.hpp
+++ b/src/Omega_h_mesh.hpp
@@ -508,6 +508,22 @@ OMEGA_H_EXPL_INST_DECL(I64)
 OMEGA_H_EXPL_INST_DECL(Real)
 #undef OMEGA_H_EXPL_INST_DECL
 
+// Global tags can have an additional variety of types.
+
+#define OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(T)                                           \
+extern template T const& Mesh::get_global_tag<T>(std::string const& name)const;         \
+extern template void Mesh::add_global_tag<T>(std::string const& name, T const& value);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(I8);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(I32);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(I64);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(Real);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(std::string);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(std::vector<I32>);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(std::vector<I64>);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(std::vector<Real>);
+OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL(std::vector<std::string>);
+#undef OMEGA_H_GLOBAL_TAGS_EXPL_INST_DECL
+
 }  // namespace Omega_h
 
 #endif


### PR DESCRIPTION
Global tags are not tied to entities, and are instead defined on the whole mesh. For instance, one may want to store a list of names of "regular" tags that have a specific meaning (e.g., the names of tags that describe whether entities belong to a particular portion of the mesh).

Since it makes no sense to discuss about number of components, I decided to store global tags not as `TagBase` pointers, but as `std::any`. Perhaps we could use a different name for global tags, something like "attribute" or "property".

Edit: this seems to work as expected. I tested it in Albany, and was able to set, retrieve, reset, retrieve a vector of strings, with the expected result.

Edit: I also need to add a unit test for this. Support for writing/reading to/from osh file will also be needed.