### PR TITLE
Make Omega_h::omega_h alias available during build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -189,6 +189,7 @@ if (Omega_h_USE_CUDA AND NOT Omega_h_USE_Kokkos)
 endif()
 
 add_library(omega_h ${Omega_h_SOURCES})
+add_library(Omega_h::omega_h ALIAS omega_h)
 
 set_property(TARGET omega_h PROPERTY CXX_STANDARD "17")
 set_property(TARGET omega_h PROPERTY CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Allows a downstream app to link against Omega_h::omega_h, regardless of whether Omega_h is used as a found dependency (via find_package) or as a sub-project (e.g., via FetchContent)

Fixes #70 