### PR TITLE
Fixes to prevent compilation errors in Albany warning-free build.

### DIFF
--- a/src/Omega_h_int_scan.cpp
+++ b/src/Omega_h_int_scan.cpp
@@ -27,7 +27,8 @@ LOs offset_scan(Read<T> a, std::string const& name) {
   out.set(0, 0);
 #if defined(OMEGA_H_USE_KOKKOS)
   auto outSub = Kokkos::subview(out.view(),std::make_pair(1,out.size()));
-  assert(outSub.size()==a.size());
+  LO outSub_size = outSub.size(); 
+  assert(outSub_size==a.size());
   auto kkOp = i32Plus<LO>();
   Kokkos::Experimental::inclusive_scan("omegah_kk_offset_scan", ExecSpace(), a.view(), outSub, kkOp, LO());
   Kokkos::fence();

--- a/src/Omega_h_int_scan.cpp
+++ b/src/Omega_h_int_scan.cpp
@@ -27,8 +27,7 @@ LOs offset_scan(Read<T> a, std::string const& name) {
   out.set(0, 0);
 #if defined(OMEGA_H_USE_KOKKOS)
   auto outSub = Kokkos::subview(out.view(),std::make_pair(1,out.size()));
-  LO outSub_size = outSub.size(); 
-  assert(outSub_size==a.size());
+  assert(static_cast<LO>(outSub.size())==a.size());
   auto kkOp = i32Plus<LO>();
   Kokkos::Experimental::inclusive_scan("omegah_kk_offset_scan", ExecSpace(), a.view(), outSub, kkOp, LO());
   Kokkos::fence();

--- a/src/Omega_h_rcFields.cpp
+++ b/src/Omega_h_rcFields.cpp
@@ -265,7 +265,6 @@ Read<T> Mesh::get_rc_mesh_array_from_rc_array(
 
   auto rc_ids = class_ids.exists() ? (ask_revClass(ent_dim, class_ids)).ab2b
                                    : (ask_revClass(ent_dim)).ab2b;
-  auto class_id_size = class_ids.exists() ? class_ids.size() : -1;
   auto n_bEnts = rc_ids.size();
   OMEGA_H_CHECK(rc_field.size() == n_bEnts * ncomps);
   if ((ent_dim == 3) && (n_bEnts != n_ents)) {

--- a/src/Omega_h_vtk.cpp
+++ b/src/Omega_h_vtk.cpp
@@ -301,7 +301,6 @@ void write_tag_impl<Real>(
 void write_tag(std::ostream& stream, TagBase const* tag, Int space_dim,
     Int ent_dim, Mesh* mesh, bool compress) {
   OMEGA_H_TIME_FUNCTION;
-  const auto ncomps = tag->ncomps();
   const auto name = tag->name();
   const auto class_ids = tag->class_ids();
   // TODO: write class id info for rc tag to file


### PR DESCRIPTION
Changing variable type to allow comparison.  Removing unused variables.