### PR TITLE
Describe Improvements

### DIFF
--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -30,7 +30,7 @@ int getNumEq(Omega_h::Mesh mesh, std::string tagname, int dim, int value) {
 }
 
 void printMPIChar(std::string output, int comm_size, int comm_rank) {
-
+#ifdef OMEGA_H_USE_MPI
     if (comm_rank) {
         MPI_Send(output.c_str(), output.size(), MPI_CHAR, 0, 0, MPI_COMM_WORLD);
     } else for (int sender=1; sender < comm_size; sender++) {
@@ -43,6 +43,9 @@ void printMPIChar(std::string output, int comm_size, int comm_rank) {
         MPI_Recv(&buf, count, MPI_CHAR, sender, 0, MPI_COMM_WORLD, &status);
         std::cout << buf;
     }
+#else
+    std::cout << output;
+#endif
 }
 
 int main(int argc, char** argv)

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -1,6 +1,15 @@
 #include <Omega_h_element.hpp>
 #include <Omega_h_file.hpp>
+#include <Omega_h_tag.hpp>
 
+template <typename T>
+void printTagInfo(Omega_h::Mesh mesh, std::ostringstream& oss, int dim, int tag, std::string type) {
+    auto tagbase = mesh.get_tag(dim, tag);
+    auto array = Omega_h::as<T>(tagbase)->array();
+    int size = array.size();
+    size /= tagbase->ncomps();
+    oss << "(" << dim << ", " << tagbase->name().c_str() << ", " << type << ", " << size << ")\n";
+}
 
 int main(int argc, char** argv)
 {
@@ -38,27 +47,14 @@ int main(int argc, char** argv)
         for (int dim=0; dim < mesh.dim(); dim++)
         for (int tag=0; tag < mesh.ntags(dim); tag++) {
             auto tagbase = mesh.get_tag(dim, tag);
-            int size;
-            std::string type;
-            if (tagbase->type() == OMEGA_H_I8) {
-                size = Omega_h::as<Omega_h::I8>(tagbase)->array().size();
-                type = "I8";
-            }
-            if (tagbase->type() == OMEGA_H_I32) {
-                size = Omega_h::as<Omega_h::I32>(tagbase)->array().size();
-                type = "I32";
-            }
-            if (tagbase->type() == OMEGA_H_I64) {
-                size = Omega_h::as<Omega_h::I64>(tagbase)->array().size();
-                type = "I64";
-            }
-            if (tagbase->type() == OMEGA_H_F64) {
-                size = Omega_h::as<Omega_h::Real>(tagbase)->array().size();
-                type = "F64";
-            }
-
-            size /= tagbase->ncomps();
-            oss << "(" << dim << ", " << tagbase->name().c_str() << ", " << type << ", " << size << ")\n";
+            if (tagbase->type() == OMEGA_H_I8)
+                printTagInfo<Omega_h::I8>(mesh, oss, dim, tag, "I8");
+            if (tagbase->type() == OMEGA_H_I32)
+                printTagInfo<Omega_h::I32>(mesh, oss, dim, tag, "I32");
+            if (tagbase->type() == OMEGA_H_I64)
+                printTagInfo<Omega_h::I64>(mesh, oss, dim, tag, "I64");
+            if (tagbase->type() == OMEGA_H_F64)
+                printTagInfo<Omega_h::Real>(mesh, oss, dim, tag, "F64");
         }
 
         std::cout << oss.str();

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -16,6 +16,14 @@ void printTagInfo(Omega_h::Mesh mesh, std::ostringstream& oss, int dim, int tag,
     oss << "\tMin, Max: " << min << ", " << max << "\n\n";
 }
 
+template <typename T>
+void printValue(Omega_h::Mesh mesh, std::string tagname, int dim, int value) {
+    auto array = mesh.get_array<T>(dim, tagname);
+    auto each_eq_to = Omega_h::each_eq_to<T>(array, value);
+    auto num = Omega_h::get_sum(each_eq_to);
+    std::cout << "Num entities: " << num << "\n";
+}
+
 int main(int argc, char** argv)
 {
     auto lib = Omega_h::Library(&argc, &argv);
@@ -81,6 +89,27 @@ int main(int argc, char** argv)
                                         << counts[2] << ", "
                                         << counts[3] << ")\n";
         std::cout << oss.str();
+    }
+
+    std::string input;
+    while(true) {
+        std::cout << "Get num entities with value: options [tagname dim value] or [exit]\n";
+
+        std::string name = "";
+        int dim=0;
+        int value=0;
+        std::cin >> name;
+        if (name == "exit") break;
+        std::cin >> dim >> value;
+        auto tagbase = mesh.get_tagbase(dim, name);
+        if (tagbase->type() == OMEGA_H_I8)
+            printValue<Omega_h::I8>(mesh, name, dim, value);
+        if (tagbase->type() == OMEGA_H_I32)
+            printValue<Omega_h::I32>(mesh, name, dim, value);
+        if (tagbase->type() == OMEGA_H_I64)
+            printValue<Omega_h::I64>(mesh, name, dim, value);
+        if (tagbase->type() == OMEGA_H_F64)
+            printValue<Omega_h::Real>(mesh, name, dim, value);
     }
     return 0;
 }

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -34,22 +34,31 @@ int main(int argc, char** argv)
         for(int dim=0; dim < mesh.dim(); dim++)
             oss << "(" << dim << ", " << counts[dim] << ", " << imb[dim] << ")\n";
 
-        oss << "\nTags by Dimension: (Dim, Tag, Size per Entity)\n";
+        oss << "\nTags by Dimension: (Dim, Tag, Type, Size per Number of Components)\n";
         for (int dim=0; dim < mesh.dim(); dim++)
         for (int tag=0; tag < mesh.ntags(dim); tag++) {
             auto tagbase = mesh.get_tag(dim, tag);
             int size;
-            if (tagbase->type() == OMEGA_H_I8)
-                size = mesh.get_tag<Omega_h::I8>(dim, tagbase->name())->array().size();
-            if (tagbase->type() == OMEGA_H_I32)
-                size = mesh.get_tag<Omega_h::I32>(dim, tagbase->name())->array().size();
-            if (tagbase->type() == OMEGA_H_I64)
-                size = mesh.get_tag<Omega_h::I64>(dim, tagbase->name())->array().size();
-            if (tagbase->type() == OMEGA_H_F64)
-                size = mesh.get_tag<Omega_h::Real>(dim, tagbase->name())->array().size();
+            std::string type;
+            if (tagbase->type() == OMEGA_H_I8) {
+                size = Omega_h::as<Omega_h::I8>(tagbase)->array().size();
+                type = "I8";
+            }
+            if (tagbase->type() == OMEGA_H_I32) {
+                size = Omega_h::as<Omega_h::I32>(tagbase)->array().size();
+                type = "I32";
+            }
+            if (tagbase->type() == OMEGA_H_I64) {
+                size = Omega_h::as<Omega_h::I64>(tagbase)->array().size();
+                type = "I64";
+            }
+            if (tagbase->type() == OMEGA_H_F64) {
+                size = Omega_h::as<Omega_h::Real>(tagbase)->array().size();
+                type = "F64";
+            }
 
-            size /= mesh.nents(dim);
-            oss << "(" << dim << ", " << tagbase->name().c_str() << ", " << size << ")\n";
+            size /= tagbase->ncomps();
+            oss << "(" << dim << ", " << tagbase->name().c_str() << ", " << type << ", " << size << ")\n";
         }
 
         std::cout << oss.str();

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
         for(int dim=0; dim < mesh.dim(); dim++)
             oss << "(" << dim << ", " << counts[dim] << ", " << imb[dim] << ")\n";
 
-        oss << "\nTag Properties: (Name, Dim, Type)\n";
+        oss << "\nTag Properties by Dimension: (Name, Dim, Type)\n";
         for (int dim=0; dim < mesh.dim(); dim++)
         for (int tag=0; tag < mesh.ntags(dim); tag++) {
             auto tagbase = mesh.get_tag(dim, tag);

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -1,14 +1,19 @@
 #include <Omega_h_element.hpp>
 #include <Omega_h_file.hpp>
 #include <Omega_h_tag.hpp>
+#include <Omega_h_array_ops.hpp>
 
 template <typename T>
 void printTagInfo(Omega_h::Mesh mesh, std::ostringstream& oss, int dim, int tag, std::string type) {
     auto tagbase = mesh.get_tag(dim, tag);
     auto array = Omega_h::as<T>(tagbase)->array();
-    int size = array.size();
-    size /= tagbase->ncomps();
-    oss << "(" << dim << ", " << tagbase->name().c_str() << ", " << type << ", " << size << ")\n";
+
+    Omega_h::Real min = get_min(array);
+    Omega_h::Real max = get_max(array);
+
+    oss << "(" << tagbase->name().c_str() << ", " << dim << ", " << type << ")\n";
+    oss << "\tNum Components: " << tagbase->ncomps() << "\n";
+    oss << "\tMin, Max: " << min << ", " << max << "\n\n";
 }
 
 int main(int argc, char** argv)
@@ -43,7 +48,7 @@ int main(int argc, char** argv)
         for(int dim=0; dim < mesh.dim(); dim++)
             oss << "(" << dim << ", " << counts[dim] << ", " << imb[dim] << ")\n";
 
-        oss << "\nTags by Dimension: (Dim, Tag, Type, Size per Number of Components)\n";
+        oss << "\nTag Properties: (Name, Dim, Type)\n";
         for (int dim=0; dim < mesh.dim(); dim++)
         for (int tag=0; tag < mesh.ntags(dim); tag++) {
             auto tagbase = mesh.get_tag(dim, tag);

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -106,6 +106,18 @@ int main(int argc, char** argv)
                                         << counts[2] << ", "
                                         << counts[3] << ")\n";
         std::cout << oss.str();
+
+        comm->barrier();
+        if (!rank) std::cout << "\nPer Rank Mesh Entity Owned: (Rank: Entity Owned by Dim <0,1,2,3>)\n";
+        comm->barrier();
+        oss.str(""); // clear the stream
+        for (int dim=0; dim < mesh.dim(); dim++)
+            counts[dim] = mesh.nents_owned(dim);
+        oss << "(" << rank << ": " << counts[0] << ", "
+                                        << counts[1] << ", "
+                                        << counts[2] << ", "
+                                        << counts[3] << ")\n";
+        std::cout << oss.str();
     }
 
     if (cmdline.parsed("--tag-info")) {

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -2,6 +2,7 @@
 #include <Omega_h_file.hpp>
 #include <Omega_h_tag.hpp>
 #include <Omega_h_array_ops.hpp>
+#include <iomanip>
 
 template <typename T>
 void printTagInfo(Omega_h::Mesh mesh, std::ostringstream& oss, int dim, int tag, std::string type) {
@@ -11,9 +12,13 @@ void printTagInfo(Omega_h::Mesh mesh, std::ostringstream& oss, int dim, int tag,
     Omega_h::Real min = get_min(array);
     Omega_h::Real max = get_max(array);
 
-    oss << "(" << tagbase->name().c_str() << ", " << dim << ", " << type << ")\n";
-    oss << "\tNum Components: " << tagbase->ncomps() << "\n";
-    oss << "\tMin, Max: " << min << ", " << max << "\n\n";
+    oss << std::setw(18) << std::left << tagbase->name().c_str()
+        << std::setw(5) << std::left << dim 
+        << std::setw(7) << std::left << type 
+        << std::setw(5) << std::left << tagbase->ncomps() 
+        << std::setw(10) << std::left << min 
+        << std::setw(10) << std::left << max 
+        << "\n";
 }
 
 template <typename T>
@@ -55,7 +60,7 @@ int main(int argc, char** argv)
         for(int dim=0; dim < mesh.dim(); dim++)
             oss << "(" << dim << ", " << counts[dim] << ", " << imb[dim] << ")\n";
 
-        oss << "\nTag Properties by Dimension: (Name, Dim, Type)\n";
+        oss << "\nTag Properties by Dimension: (Name, Dim, Type, Number of Components, Min. Value, Max. Value)\n";
         for (int dim=0; dim < mesh.dim(); dim++)
         for (int tag=0; tag < mesh.ntags(dim); tag++) {
             auto tagbase = mesh.get_tag(dim, tag);

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
     Omega_h::Mesh mesh = Omega_h::read_mesh_file(argv[1], lib.world());
 
     auto verbose = false;
-    if (argc == 3) verbose = (std::string(argv[2]) == "on");
+    if (argc >= 3) verbose = (std::string(argv[2]) == "on");
 
     const int rank = comm->rank();
 
@@ -105,8 +105,9 @@ int main(int argc, char** argv)
         if (tagbase->type() == OMEGA_H_F64)
             numEq = getNumEq<Omega_h::Real>(mesh, name, dim, value);
         
+        if (!rank) std::cout << "\nInput: (" << name << " " << dim << " " << value <<"), Output: (Rank, Num Entities Equal to Value)\n";
         comm->barrier();
-        std::cout << "Rank, Num Entities Eq: " << rank << ", " << numEq << "\n";
+        std::cout << "(" << rank << ", " << numEq << ")\n";
         return 0;
     }
     return 0;

--- a/src/describe.cpp
+++ b/src/describe.cpp
@@ -32,6 +32,21 @@ int main(int argc, char** argv)
 
     auto verbose = false;
     if (argc == 3) verbose = (std::string(argv[2]) == "on");
+    if (argc > 3) {
+        std::string name = std::string(argv[3]);
+        int dim = atoi(argv[4]);
+        int value = atoi(argv[5]);
+        auto tagbase = mesh.get_tagbase(dim, name);
+        if (tagbase->type() == OMEGA_H_I8)
+            printValue<Omega_h::I8>(mesh, name, dim, value);
+        if (tagbase->type() == OMEGA_H_I32)
+            printValue<Omega_h::I32>(mesh, name, dim, value);
+        if (tagbase->type() == OMEGA_H_I64)
+            printValue<Omega_h::I64>(mesh, name, dim, value);
+        if (tagbase->type() == OMEGA_H_F64)
+            printValue<Omega_h::Real>(mesh, name, dim, value);
+        return 0;
+    }
 
     const int rank = comm->rank();
 
@@ -89,27 +104,6 @@ int main(int argc, char** argv)
                                         << counts[2] << ", "
                                         << counts[3] << ")\n";
         std::cout << oss.str();
-    }
-
-    std::string input;
-    while(true) {
-        std::cout << "Get num entities with value: options [tagname dim value] or [exit]\n";
-
-        std::string name = "";
-        int dim=0;
-        int value=0;
-        std::cin >> name;
-        if (name == "exit") break;
-        std::cin >> dim >> value;
-        auto tagbase = mesh.get_tagbase(dim, name);
-        if (tagbase->type() == OMEGA_H_I8)
-            printValue<Omega_h::I8>(mesh, name, dim, value);
-        if (tagbase->type() == OMEGA_H_I32)
-            printValue<Omega_h::I32>(mesh, name, dim, value);
-        if (tagbase->type() == OMEGA_H_I64)
-            printValue<Omega_h::I64>(mesh, name, dim, value);
-        if (tagbase->type() == OMEGA_H_F64)
-            printValue<Omega_h::Real>(mesh, name, dim, value);
     }
     return 0;
 }


### PR DESCRIPTION
Related to this issue: https://github.com/SCOREC/omega_h/issues/77#issue-2036576442

In the describe tool, we should add the following info on each tag:

- number of entities with a given values (this would require additional user input: tag name and value)
- min and max across all processes
- type (int, bool, float, real, etc.)
- change ‘size per entity’ → ‘number of components’