### PR TITLE
New weekly test time

### DIFF
--- a/.github/workflows/systems.yml
+++ b/.github/workflows/systems.yml
@@ -1,8 +1,8 @@
 name: Systems
 on:
   schedule:
-    # Monday 4:30 UTC or 00:30 EDT
-    - cron: '30 4 * * 1' 
+    # Monday 5:05 UTC or 01:05 EDT
+    - cron: '05 5 * * 1' 
 
 concurrency:
   group: systems-omega_h


### PR DESCRIPTION
pushed weekly test back so that it doesn't run at the same time as our other tests