### PR TITLE
bboxWrap correction

### DIFF
--- a/src/Omega_h_bbox.cpp
+++ b/src/Omega_h_bbox.cpp
@@ -10,10 +10,10 @@ template< int N >
 struct bboxWrap {
   BBox<N> box;
 
-  KOKKOS_INLINE_FUNCTION   // Default constructor - Initialize to 0's
+  KOKKOS_INLINE_FUNCTION   // Default constructor
   bboxWrap() {
-    box.min = max_float_vector<N>();
-    box.max = min_float_vector<N>();
+    box.min = max_vector<N>();
+    box.max = min_vector<N>();
   }
   KOKKOS_INLINE_FUNCTION   // Copy Constructor
   bboxWrap(const bboxWrap & rhs) {

--- a/src/Omega_h_bbox.cpp
+++ b/src/Omega_h_bbox.cpp
@@ -12,9 +12,8 @@ struct bboxWrap {
 
   KOKKOS_INLINE_FUNCTION   // Default constructor - Initialize to 0's
   bboxWrap() {
-    const auto zero = zero_vector<N>();
-    box.min = zero;
-    box.max = zero;
+    box.min = max_float_vector<N>();
+    box.max = min_float_vector<N>();
   }
   KOKKOS_INLINE_FUNCTION   // Copy Constructor
   bboxWrap(const bboxWrap & rhs) {

--- a/src/Omega_h_bbox.cpp
+++ b/src/Omega_h_bbox.cpp
@@ -12,8 +12,8 @@ struct bboxWrap {
 
   KOKKOS_INLINE_FUNCTION   // Default constructor
   bboxWrap() {
-    box.min = max_vector<N>();
-    box.max = min_vector<N>();
+    box.min = fill_vector<N>(Kokkos::Experimental::finite_max_v<Real>);
+    box.max = fill_vector<N>(Kokkos::Experimental::finite_min_v<Real>);
   }
   KOKKOS_INLINE_FUNCTION   // Copy Constructor
   bboxWrap(const bboxWrap & rhs) {

--- a/src/Omega_h_vector.hpp
+++ b/src/Omega_h_vector.hpp
@@ -150,16 +150,6 @@ OMEGA_H_INLINE Vector<n> zero_vector() OMEGA_H_NOEXCEPT {
   return fill_vector<n>(0.0);
 }
 
-template <Int n>
-OMEGA_H_INLINE Vector<n> max_vector() OMEGA_H_NOEXCEPT {
-  return fill_vector<n>(Kokkos::Experimental::finite_max_v<Real>);
-}
-
-template <Int n>
-OMEGA_H_INLINE Vector<n> min_vector() OMEGA_H_NOEXCEPT {
-  return fill_vector<n>(Kokkos::Experimental::finite_min_v<Real>);
-}
-
 /* Moore-Penrose pseudo-inverse of a vector */
 template <Int n>
 OMEGA_H_INLINE Vector<n> pseudo_invert(Vector<n> a) OMEGA_H_NOEXCEPT {

--- a/src/Omega_h_vector.hpp
+++ b/src/Omega_h_vector.hpp
@@ -150,6 +150,16 @@ OMEGA_H_INLINE Vector<n> zero_vector() OMEGA_H_NOEXCEPT {
   return fill_vector<n>(0.0);
 }
 
+template <Int n>
+OMEGA_H_INLINE Vector<n> max_float_vector() OMEGA_H_NOEXCEPT {
+  return fill_vector<n>(Kokkos::Experimental::finite_max_v<float>);
+}
+
+template <Int n>
+OMEGA_H_INLINE Vector<n> min_float_vector() OMEGA_H_NOEXCEPT {
+  return fill_vector<n>(Kokkos::Experimental::finite_min_v<float>);
+}
+
 /* Moore-Penrose pseudo-inverse of a vector */
 template <Int n>
 OMEGA_H_INLINE Vector<n> pseudo_invert(Vector<n> a) OMEGA_H_NOEXCEPT {

--- a/src/Omega_h_vector.hpp
+++ b/src/Omega_h_vector.hpp
@@ -151,13 +151,13 @@ OMEGA_H_INLINE Vector<n> zero_vector() OMEGA_H_NOEXCEPT {
 }
 
 template <Int n>
-OMEGA_H_INLINE Vector<n> max_float_vector() OMEGA_H_NOEXCEPT {
-  return fill_vector<n>(Kokkos::Experimental::finite_max_v<float>);
+OMEGA_H_INLINE Vector<n> max_vector() OMEGA_H_NOEXCEPT {
+  return fill_vector<n>(Kokkos::Experimental::finite_max_v<Real>);
 }
 
 template <Int n>
-OMEGA_H_INLINE Vector<n> min_float_vector() OMEGA_H_NOEXCEPT {
-  return fill_vector<n>(Kokkos::Experimental::finite_min_v<float>);
+OMEGA_H_INLINE Vector<n> min_vector() OMEGA_H_NOEXCEPT {
+  return fill_vector<n>(Kokkos::Experimental::finite_min_v<Real>);
 }
 
 /* Moore-Penrose pseudo-inverse of a vector */

--- a/src/unit_mesh.cpp
+++ b/src/unit_mesh.cpp
@@ -235,6 +235,10 @@ static void test_hilbert() {
 }
 
 static void test_bbox() {
+  OMEGA_H_CHECK(are_close(BBox<2>(vector_2(-10, -15), vector_2(-1, -1)),
+      find_bounding_box<2>(Reals({-3, -12, -10, -1, -1, -15, -3, -2}))));
+  OMEGA_H_CHECK(are_close(BBox<2>(vector_2(1, 1), vector_2(10, 15)),
+      find_bounding_box<2>(Reals({3, 12, 10, 1, 1, 15, 3, 2}))));
   OMEGA_H_CHECK(are_close(BBox<2>(vector_2(-3, -3), vector_2(3, 3)),
       find_bounding_box<2>(Reals({0, -3, 3, 0, 0, 3, -3, 0}))));
   OMEGA_H_CHECK(are_close(BBox<3>(vector_3(-3, -3, -3), vector_3(3, 3, 3)),


### PR DESCRIPTION
The `bbcxWrap()` was initialized with zero, resulting in `get_bounding_box` or `find_bounding_box` giving wrong answers when the mesh lives on only one side of an axis. Instead of zero, I used `Kokkos::Experimental::finite_min_v` and `finite_max_v` for `max` and `min` respectively. I also added two test cases for bbox in `unit_mesh.cpp`.