### PR TITLE
fix cuda build with kokkos disabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,6 +196,9 @@ add_library(Omega_h::omega_h ALIAS omega_h)
 set_property(TARGET omega_h PROPERTY CXX_STANDARD "17")
 set_property(TARGET omega_h PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET omega_h PROPERTY CXX_EXTENSIONS OFF)
+if (Omega_h_USE_CUDA)
+  set_property(TARGET omega_h PROPERTY CUDA_ARCHITECTURES ${Omega_h_CUDA_ARCH})
+endif()
 
 bob_library_includes(omega_h)
 

--- a/src/Omega_h_array.hpp
+++ b/src/Omega_h_array.hpp
@@ -10,6 +10,7 @@
 #include <Omega_h_memory.hpp>
 #else
 #include <Omega_h_shared_alloc.hpp>
+#include <memory> //shared_ptr
 #include <string>
 #endif
 
@@ -136,7 +137,7 @@ class HostRead {
 #if defined(OMEGA_H_USE_KOKKOS)
   typename Kokkos::View<const T*, Kokkos::HostSpace> mirror_;
 #elif defined(OMEGA_H_USE_CUDA)
-  std::shared_ptr<T> mirror_;
+  std::shared_ptr<T[]> mirror_;
 #endif
  public:
   using value_type = T;
@@ -155,7 +156,7 @@ class HostWrite {
 #ifdef OMEGA_H_USE_KOKKOS
   typename View<T*>::HostMirror mirror_;
 #elif defined(OMEGA_H_USE_CUDA)
-  std::shared_ptr<T> mirror_;
+  std::shared_ptr<T[]> mirror_;
 #endif
  public:
   using value_type = T;


### PR DESCRIPTION
This PR addresses the build issue described in #116.  Note, there is one failing tests when building with GCC 12.3.0 and CUDA 12.1.105:

```
         14 - run_test_r3d (Failed)
```