### PR TITLE
Use Kokkos `atomic_inc` in place of `atomic_increment`

### DIFF
--- a/src/Omega_h_atomics.hpp
+++ b/src/Omega_h_atomics.hpp
@@ -38,7 +38,7 @@ OMEGA_H_DEVICE int atomic_fetch_add(int* const dest, const int val) {
 
 OMEGA_H_DEVICE void atomic_increment(int* const dest) {
 #if defined(OMEGA_H_USE_KOKKOS)
-  Kokkos::atomic_increment(dest);
+  Kokkos::atomic_inc(dest);
 #elif defined(OMEGA_H_USE_OPENMP) || defined(OMEGA_H_USE_CUDA)
   atomic_fetch_add(dest, 1);
 #else


### PR DESCRIPTION
Approximately a month ago, the development branch of kokkos deprecated calls to `atomic_increment` in favor of `atomic_inc` (see https://github.com/kokkos/kokkos/commit/e61165e807d266d5d24edd4ac5049a4fab39480e). `atomic_inc` is present in the master and release branches, so this branch replaces calls to `Kokkos:atomic_increment` with `Kokkos:atomic_inc`.