### PR TITLE
Use `constexpr` in place of `__constant__` when using the kokkos backend.

### DIFF
--- a/src/Omega_h_macros.h
+++ b/src/Omega_h_macros.h
@@ -47,19 +47,23 @@
 #define OMEGA_H_INLINE_BIG OMEGA_H_INLINE
 #define OMEGA_H_DEVICE __host__ __device__ inline
 #define OMEGA_H_LAMBDA [=] __host__ __device__
+#if defined(__CUDA_ARCH__)
 #define OMEGA_H_CONSTANT_DATA __constant__
+#else
+#define OMEGA_H_CONSTANT_DATA
+#endif
 #elif defined(OMEGA_H_USE_KOKKOS)
 #define OMEGA_H_INLINE KOKKOS_INLINE_FUNCTION
 #define OMEGA_H_INLINE_BIG OMEGA_H_INLINE
 #define OMEGA_H_DEVICE KOKKOS_INLINE_FUNCTION
 #define OMEGA_H_LAMBDA KOKKOS_LAMBDA
-#define OMEGA_H_CONSTANT_DATA 
+#define OMEGA_H_CONSTANT_DATA constexpr
 #elif defined(OMEGA_H_USE_CUDA)
 #define OMEGA_H_INLINE __host__ __device__ inline
 #define OMEGA_H_INLINE_BIG OMEGA_H_INLINE
 #define OMEGA_H_DEVICE __host__ __device__ inline
 #define OMEGA_H_LAMBDA [=] __host__ __device__
-#define OMEGA_H_CONSTANT_DATA __constant__
+#define OMEGA_H_CONSTANT_DATA constexpr
 #elif defined(_MSC_VER)
 #define OMEGA_H_INLINE __forceinline
 #define OMEGA_H_INLINE_BIG inline


### PR DESCRIPTION
Variables with the `__constant__` qualifier cannot be read in Kokkos host functions, causing the compiler to throw a warning. This branch replaces the `__constant__` qualifier with `constexpr` on non-CUDA platforms to resolve this warning. The changes were tested on Perlmutter and Frontier using the Delta Wing test, showing a less than 1% increase in completion time.