### PR TITLE
Resolve warning in transform_reduce function

### DIFF
--- a/src/Omega_h_reduce.hpp
+++ b/src/Omega_h_reduce.hpp
@@ -47,6 +47,7 @@ Result transform_reduce(
     Iterator first, Iterator last, Result init, Op op, Tranform transform) {
   fprintf(stderr, "transform_reduce wrapper.  We shouldn't be here... exiting\n");
   OMEGA_H_CHECK(false);
+  return Result();
 }
 
 #elif defined(OMEGA_H_USE_CUDA)


### PR DESCRIPTION
Return a Result() in `transform_reduce` to resolve the associated compile-time warning.