### PR TITLE
exodus: read element fields, skip empty node sets

### DIFF
--- a/src/Omega_h_exodus.cpp
+++ b/src/Omega_h_exodus.cpp
@@ -341,6 +341,9 @@ void read_mesh(int file, Mesh* mesh, bool verbose, int classify_with) {
         std::cout << "P" << mesh->comm()->rank() << ": node set " << node_set_ids[i] << " has " << nentries
                   << " nodes" << std::endl;
       }
+      if( !nentries ) { //don't process empty node sets
+        continue;
+      }
       HostWrite<LO> h_set_nodes2nodes(nentries);
       CALL(ex_get_set(file, EX_NODE_SET, node_set_ids[i],
           h_set_nodes2nodes.data(), nullptr));

--- a/src/Omega_h_file.hpp
+++ b/src/Omega_h_file.hpp
@@ -87,6 +87,9 @@ void read_mesh(int exodus_file, Mesh* mesh, bool verbose = false,
 void read_nodal_fields(int exodus_file, Mesh* mesh, int time_step,
     std::string const& prefix = "", std::string const& postfix = "",
     bool verbose = false);
+void read_element_fields(int exodus_file, Mesh* mesh, int time_step,
+    std::string const& prefix = "", std::string const& postfix = "",
+    bool verbose = false);
 void write(filesystem::path const& path, Mesh* mesh, bool verbose = false,
     int classify_with = NODE_SETS | SIDE_SETS);
 Mesh read_sliced(filesystem::path const& path, CommPtr comm,

--- a/src/exo2osh.cpp
+++ b/src/exo2osh.cpp
@@ -42,6 +42,8 @@ int main(int argc, char** argv) {
     if (ntime_steps > 0) {
       Omega_h::exodus::read_nodal_fields(
           exodus_file, &mesh, ntime_steps - 1, "", "", verbose);
+      Omega_h::exodus::read_element_fields(
+          exodus_file, &mesh, ntime_steps - 1, "", "", verbose);
     }
     Omega_h::exodus::close(exodus_file);
   } else {


### PR DESCRIPTION
This PR adds support for skipping over empty node sets and reading fields associated with mesh elements.