### PR TITLE
Use Kokkos sort_by_key for stable sorting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ set(Omega_h_KEY_BOOLS
     Omega_h_ENABLE_DEMANGLED_STACKTRACE
     Omega_h_DBG
     Omega_h_USE_Kokkos
+    Omega_h_FORCE_KOKKOS_SORT
     Omega_h_USE_OpenMP
     Omega_h_USE_CUDA
     Omega_h_USE_SYCL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ bob_option(Omega_h_ENABLE_DEMANGLED_STACKTRACE "Add linker options to enable hum
 bob_option(Omega_h_DBG "Enable debug prints, stacktraces, etc." OFF)
 bob_option(Omega_h_GPU_CHECK "Run GPU check after each test" OFF) #the check command is hardcoded!
 bob_option(Omega_h_USE_CTAGS "Generate Ctags" OFF)
+bob_option(Omega_h_FORCE_KOKKOS_SORT "Force omega_h sort to use kokkos sortbykey." ON)
 
 if (Omega_h_ENABLE_DEMANGLED_STACKTRACE)
   message(STATUS "CMAKE_BUILD_TYPE= ${CMAKE_BUILD_TYPE}")

--- a/src/Omega_h_sort.cpp
+++ b/src/Omega_h_sort.cpp
@@ -77,7 +77,7 @@ struct CompareKeySets {
       T y = keys_[b * N + i];
       if (x != y) return x < y;
     }
-    return false;
+    return a < b;
   }
 };
 


### PR DESCRIPTION
Omega_h currently relies on a set of vendor specific sorting routines captured in the `parallel_sort()` function. This pull request replaces the vendor specific sorting routines with Kokkos' new `sort_by_key()` routine, which provides a stable sorting routine utilizing the same comparator as the `parallel_sort()` function. A compile time option `OMEGA_H_FORCE_KOKKOS_SORT` is enabled by default and forces the use of the new sorting routine. It can be disabled to fall back to `parallel_sort()`.