### PR TITLE
Changes to support conversion of multiple 2D planes from a single Simmetrix mesh to multiple Omega_h 2D planer meshes

### DIFF
--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -97,7 +97,7 @@ string(REGEX REPLACE
   "${SIM_VERSION}")
 
 set(MIN_VALID_SIM_VERSION 16.0.210606)
-set(MAX_VALID_SIM_VERSION 2023.1-231028)
+set(MAX_VALID_SIM_VERSION 2025.0-250108)
 if( ${SKIP_SIMMETRIX_VERSION_CHECK} )
   message(STATUS "Skipping Simmetrix SimModSuite version check."
     " This may result in undefined behavior")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -712,6 +712,7 @@ set(Omega_h_HEADERS
   Omega_h_math_lang.hpp
   Omega_h_matrix.hpp
   Omega_h_mesh.hpp
+  Omega_h_meshsim.hpp
   Omega_h_mixedMesh.hpp
   Omega_h_metric.hpp
   Omega_h_mpi.h

--- a/src/Omega_h_adios2.hpp
+++ b/src/Omega_h_adios2.hpp
@@ -14,6 +14,7 @@ void write(filesystem::path const& path, Mesh *mesh, std::string pref="");
 
 Mesh read(filesystem::path const& path, Library* lib, std::string pref="");
 
+void write_mesh(adios2::IO &io, adios2::Engine & writer, Mesh* mesh, std::string pref);
 } // namespace adios
 
 } // namespace Omega_h

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -121,6 +121,8 @@ SimMeshEntInfo::SimMeshEntInfo(const SimMesh& simMesh, bool hasNumbering_in) {
   int numR = mR.size(); 
   std::array<int,4> numEnts = {numV, numE, numF, numR};
   maxDim = getMaxDim(numEnts);
+  std::cout << "Max Dimension = " << maxDim << "\n";
+  std::cout << "Mesh is " <<(maxDim==2?"2D":"3D") << "\n";
 }
 
 SimMeshEntInfo::VertexInfo SimMeshEntInfo::readVerts(pMeshNex numbering) {
@@ -138,6 +140,13 @@ SimMeshEntInfo::VertexInfo SimMeshEntInfo::readVerts(pMeshNex numbering) {
     vtx = mV[i];
     double xyz[3];
     V_coord(vtx,xyz);
+     
+     // Convert coordinates from 3d cylindrical to 2d cartesian
+     double r = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1]);
+     xyz[0] = r;  // x = r =sqrt(x^2 + y^2)
+     xyz[1] = xyz[2];  // y = z  
+     xyz[2] = 0.0;  // z = 0.0
+    
     if( maxDim < 3 && xyz[2] != 0 )
       Omega_h_fail("The z coordinate must be zero for a 2d mesh!\n");
     for(int j=0; j<maxDim; j++) {

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -1,17 +1,4 @@
-#include "Omega_h_file.hpp"
-#include "Omega_h_build.hpp"
-#include "Omega_h_class.hpp"
-#include "Omega_h_map.hpp"
-#include "Omega_h_vector.hpp"
-#include "Omega_h_mesh.hpp"
-#include "Omega_h_mixedMesh.hpp"
-#include "Omega_h_adj.hpp"
-
-#include "MeshSim.h" // required to load GeomSim models in '.smd' files
-#include "SimUtil.h"
-#ifdef OMEGA_H_USE_SIMDISCRETE
-#include "SimDiscrete.h"  // required to load discrete models in '.smd' files
-#endif
+#include "Omega_h_meshsim.hpp"
 
 namespace {
   int classId(pEntity e) {
@@ -40,23 +27,21 @@ namespace Omega_h {
 
 namespace meshsim {
 
-struct SimMeshInfo {
-  int count_tet;
-  int count_hex;
-  int count_wedge;
-  int count_pyramid;
-  int count_tri;
-  int count_quad;
-  bool is_simplex;
-  bool is_hypercube;
-};
 
-SimMeshInfo getSimMeshInfo(pMesh m) {
+SimMesh::SimMesh(std::vector <pVertex> vertices, std::vector <pEdge> edges, 
+          std::vector <pFace> faces, std::vector <pRegion> regions) {
+  mV = vertices; 
+  mE = edges;
+  mF = faces;
+  mR = regions;
+}
+
+SimMeshInfo getSimMeshInfo(const SimMesh& mesh) {
   SimMeshInfo info = {0,0,0,0,0,0,false,false};
 
-  RIter regions = M_regionIter(m);
   pRegion rgn;
-  while ((rgn = (pRegion) RIter_next(regions))) {
+  for (int i = 0; i < mesh.mR.size(); i++) {
+    rgn = mesh.mR[i];
     if (R_topoType(rgn) == Rtet) {
       info.count_tet += 1;
     }
@@ -73,11 +58,10 @@ SimMeshInfo getSimMeshInfo(pMesh m) {
       Omega_h_fail("Region is not tet, hex, wedge, or pyramid \n");
     }
   }
-  RIter_delete(regions);
 
-  FIter faces = M_faceIter(m);
   pFace face;
-  while ((face = (pFace) FIter_next(faces))) {
+  for (int i = 0; i < mesh.mF.size(); i++) {
+    face = mesh.mF[i];
     if (F_numEdges(face) == 3) {
       info.count_tri += 1;
     }
@@ -88,7 +72,6 @@ SimMeshInfo getSimMeshInfo(pMesh m) {
       Omega_h_fail ("Face is neither tri nor quad \n");
     }
   }
-  FIter_delete(faces);
 
   info.is_simplex = false;
   info.is_hypercube = false;
@@ -126,309 +109,420 @@ SimMeshInfo getSimMeshInfo(pMesh m) {
   return info;
 }
 
-struct SimMeshEntInfo {
-  int maxDim;
-  bool hasNumbering;
+SimMeshEntInfo::SimMeshEntInfo(const SimMesh& simMesh, bool hasNumbering_in) {
+  hasNumbering = hasNumbering_in;
+  mV = simMesh.mV;
+  mE = simMesh.mE;
+  mF = simMesh.mF;
+  mR = simMesh.mR;
+  int numV = mV.size();
+  int numE = mE.size();
+  int numF = mF.size();
+  int numR = mR.size(); 
+  std::array<int,4> numEnts = {numV, numE, numF, numR};
+  maxDim = getMaxDim(numEnts);
+}
 
-  SimMeshEntInfo(std::array<int,4> numEnts, bool hasNumbering_in) {
-    hasNumbering = hasNumbering_in;
-    maxDim = getMaxDim(numEnts);
-  }
+SimMeshEntInfo::VertexInfo SimMeshEntInfo::readVerts(pMeshNex numbering) {
+  const int numVtx = mV.size();
+  VertexInfo vtxInfo;
+  vtxInfo.coords = HostWrite<Real>(numVtx*maxDim);
+  vtxInfo.id = HostWrite<LO>(numVtx);
+  vtxInfo.dim = HostWrite<I8>(numVtx);
+  if(hasNumbering)
+    vtxInfo.numbering = HostWrite<LO>(numVtx);
 
-  struct EntClass {
-    HostWrite<LO> id;
-    HostWrite<I8> dim;
-    HostWrite<LO> verts;
-  };
-
-  struct VertexInfo {
-    HostWrite<Real> coords;
-    HostWrite<LO> id;
-    HostWrite<I8> dim;
-    HostWrite<LO> numbering;
-  };
-
-  VertexInfo readVerts(pMesh m,pMeshNex numbering) {
-    const int numVtx = M_numVertices(m);
-    VertexInfo vtxInfo;
-    vtxInfo.coords = HostWrite<Real>(numVtx*maxDim);
-    vtxInfo.id = HostWrite<LO>(numVtx);
-    vtxInfo.dim = HostWrite<I8>(numVtx);
-    if(hasNumbering)
-      vtxInfo.numbering = HostWrite<LO>(numVtx);
-
-    VIter vertices = M_vertexIter(m);
-    pVertex vtx;
-    LO v = 0;
-    while ((vtx = (pVertex) VIter_next(vertices))) {
-      double xyz[3];
-      V_coord(vtx,xyz);
-      if( maxDim < 3 && xyz[2] != 0 )
-        Omega_h_fail("The z coordinate must be zero for a 2d mesh!\n");
-      for(int j=0; j<maxDim; j++) {
-        vtxInfo.coords[v * maxDim + j] = xyz[j];
-      }
-      vtxInfo.id[v] = classId(vtx);
-      vtxInfo.dim[v] = classType(vtx);
-      if(hasNumbering) {
-        vtxInfo.numbering[v] = getNumber(numbering,vtx);
-      }
-      ++v;
+  pVertex vtx;
+  LO v = 0;
+  for (int i = 0; i <numVtx; i++) {
+    vtx = mV[i];
+    double xyz[3];
+    V_coord(vtx,xyz);
+    if( maxDim < 3 && xyz[2] != 0 )
+      Omega_h_fail("The z coordinate must be zero for a 2d mesh!\n");
+    for(int j=0; j<maxDim; j++) {
+      vtxInfo.coords[v * maxDim + j] = xyz[j];
     }
-    VIter_delete(vertices);
-    return vtxInfo;
-  }
-
-  void setVtxIds(pPList listVerts, const int vtxPerEnt, const int entIdx, HostWrite<LO>& verts) {
-    assert (PList_size(listVerts) == vtxPerEnt);
-    void *iter = 0;
-    int i = 0;
-    pVertex vtx;
-    while ((vtx = (pVertex) PList_next(listVerts, &iter))) {
-      verts[entIdx*vtxPerEnt+i] = EN_id(vtx);
-      i++;
+    vtxInfo.id[v] = classId(vtx);
+    vtxInfo.dim[v] = classType(vtx);
+    if(hasNumbering) {
+      vtxInfo.numbering[v] = getNumber(numbering,vtx);
     }
-    PList_delete(listVerts);
+    ++v;
   }
+  return vtxInfo;
+}
 
-  EntClass readEdges(pMesh m) {
-    const int numEdges = M_numEdges(m);
-    EntClass edgeClass;
-    edgeClass.verts = HostWrite<LO>(numEdges*2);
-    edgeClass.id = HostWrite<LO>(numEdges);
-    edgeClass.dim = HostWrite<I8>(numEdges);
-    const int vtxPerEdge = 2;
-    auto edgeIdx = 0;
+void SimMeshEntInfo::setVtxIds(pPList listVerts, const int vtxPerEnt, const int entIdx, HostWrite<LO>& verts) {
+  assert (PList_size(listVerts) == vtxPerEnt);
+  void *iter = 0;
+  int i = 0;
+  pVertex vtx;
+  while ((vtx = (pVertex) PList_next(listVerts, &iter))) {
+    verts[entIdx*vtxPerEnt+i] = EN_id(vtx);
+    i++;
+  }
+  PList_delete(listVerts);
+}
+
+SimMeshEntInfo::EntClass SimMeshEntInfo::readEdges() {
+  const int numEdges = mE.size();
+  EntClass edgeClass;
+  edgeClass.verts = HostWrite<LO>(numEdges*2);
+  edgeClass.id = HostWrite<LO>(numEdges);
+  edgeClass.dim = HostWrite<I8>(numEdges);
+  const int vtxPerEdge = 2;
+  auto edgeIdx = 0;
     
-    EIter edges = M_edgeIter(m);
-    pEdge edge;
-    while ((edge = (pEdge) EIter_next(edges))) {
-      pPList verts = PList_new();
-      //there is no E_vertices(edge) function that returns a list
-      verts = PList_append(verts, E_vertex(edge,0));
-      verts = PList_append(verts, E_vertex(edge,1));
-      setVtxIds(verts, vtxPerEdge, edgeIdx, edgeClass.verts);
-      edgeClass.id[edgeIdx] = classId(edge);
-      edgeClass.dim[edgeIdx] = classType(edge);
-      edgeIdx++;
-    }
-    EIter_delete(edges);
-    return edgeClass;
+  pEdge edge;
+  for (int i = 0; i < numEdges; i++) {
+    edge = mE[i];
+    pPList verts = PList_new();
+    //there is no E_vertices(edge) function that returns a list
+    verts = PList_append(verts, E_vertex(edge,0));
+    verts = PList_append(verts, E_vertex(edge,1));
+    setVtxIds(verts, vtxPerEdge, edgeIdx, edgeClass.verts);
+    edgeClass.id[edgeIdx] = classId(edge);
+    edgeClass.dim[edgeIdx] = classType(edge);
+    edgeIdx++;
   }
+  return edgeClass;
+}
 
-  struct MixedFaceClass {
-    EntClass tri;
-    EntClass quad;
-  };
+SimMeshEntInfo::MixedFaceClass SimMeshEntInfo::readMixedFaces(GO count_tri, GO count_quad) {
+  EntClass tri;
+  tri.verts = HostWrite<LO>(count_tri*3);
+  tri.id = HostWrite<LO>(count_tri);
+  tri.dim = HostWrite<I8>(count_tri);
+  const int edgePerTri = 3;
+  const int vtxPerTri = 3;
+  int triIdx = 0;
 
-  MixedFaceClass readMixedFaces(pMesh m, GO count_tri, GO count_quad) {
-    EntClass tri;
-    tri.verts = HostWrite<LO>(count_tri*3);
-    tri.id = HostWrite<LO>(count_tri);
-    tri.dim = HostWrite<I8>(count_tri);
-    const int edgePerTri = 3;
-    const int vtxPerTri = 3;
-    int triIdx = 0;
+  EntClass quad;
+  quad.verts = HostWrite<LO>(count_quad*4);
+  quad.id = HostWrite<LO>(count_quad);
+  quad.dim = HostWrite<I8>(count_quad);
+  const int edgePerQuad = 4;
+  const int vtxPerQuad = 4;
+  int quadIdx = 0;
 
-    EntClass quad;
-    quad.verts = HostWrite<LO>(count_quad*4);
-    quad.id = HostWrite<LO>(count_quad);
-    quad.dim = HostWrite<I8>(count_quad);
-    const int edgePerQuad = 4;
-    const int vtxPerQuad = 4;
-    int quadIdx = 0;
-
-    FIter faces = M_faceIter(m);
-    pFace face;
-    while ((face = (pFace) FIter_next(faces))) {
-      if (F_numEdges(face) == edgePerTri) {
-        pPList verts = F_vertices(face,1);
-        setVtxIds(verts, vtxPerTri, triIdx, tri.verts);
-        tri.id[triIdx] = classId(face);
-        tri.dim[triIdx] = classType(face);
-        triIdx++;
-      }
-      else if (F_numEdges(face) == edgePerQuad) {
-        pPList verts = F_vertices(face,1);
-        setVtxIds(verts, vtxPerQuad, quadIdx, quad.verts);
-        quad.id[quadIdx] = classId(face);
-        quad.dim[quadIdx] = classType(face);
-        quadIdx++;
-      }
-      else {
-        Omega_h_fail ("Face is neither tri nor quad \n");
-      }
-    }
-    FIter_delete(faces);
-
-    return MixedFaceClass{tri,quad};
-  }
- 
-  EntClass readMonoTopoFaces(pMesh m, GO numFaces, LO vtxPerFace) {
-    EntClass ents;
-    ents.verts = HostWrite<LO>(numFaces*vtxPerFace);
-    ents.id = HostWrite<LO>(numFaces);
-    ents.dim = HostWrite<I8>(numFaces);
-    int faceIdx = 0;
-
-    FIter faces = M_faceIter(m);
-    pFace face;
-    while ((face = (pFace) FIter_next(faces))) {
-      assert(F_numEdges(face) == vtxPerFace);
+  const int numFaces = mF.size();
+  pFace face;
+  for (int i = 0; i < numFaces; i++) {
+    face = mF[i];
+    if (F_numEdges(face) == edgePerTri) {
       pPList verts = F_vertices(face,1);
-      setVtxIds(verts, vtxPerFace, faceIdx, ents.verts);
-      ents.id[faceIdx] = classId(face);
-      ents.dim[faceIdx] = classType(face);
-      faceIdx++;
+      setVtxIds(verts, vtxPerTri, triIdx, tri.verts);
+      tri.id[triIdx] = classId(face);
+      tri.dim[triIdx] = classType(face);
+      triIdx++;
     }
-    FIter_delete(faces);
-    return ents;
+    else if (F_numEdges(face) == edgePerQuad) {
+      pPList verts = F_vertices(face,1);
+      setVtxIds(verts, vtxPerQuad, quadIdx, quad.verts);
+      quad.id[quadIdx] = classId(face);
+      quad.dim[quadIdx] = classType(face);
+      quadIdx++;
+    }
+    else {
+      Omega_h_fail ("Face is neither tri nor quad \n");
+    }
   }
+  return MixedFaceClass{tri,quad};
+}
+ 
+SimMeshEntInfo::EntClass SimMeshEntInfo::readMonoTopoFaces(GO numFaces, LO vtxPerFace) {
+  EntClass ents;
+  ents.verts = HostWrite<LO>(numFaces*vtxPerFace);
+  ents.id = HostWrite<LO>(numFaces);
+  ents.dim = HostWrite<I8>(numFaces);
+  int faceIdx = 0;
 
-  struct MixedRgnClass {
-    EntClass tet;
-    EntClass hex;
-    EntClass wedge;
-    EntClass pyramid;
-  };
+  pFace face;
+  for (int i = 0; i < mF.size(); i++) {
+    face = mF[i];
+    assert(F_numEdges(face) == vtxPerFace);
+    pPList verts = F_vertices(face,1);
+    setVtxIds(verts, vtxPerFace, faceIdx, ents.verts);
+    ents.id[faceIdx] = classId(face);
+    ents.dim[faceIdx] = classType(face);
+    faceIdx++;
+  }
+  return ents;
+}
 
-  MixedRgnClass readMixedTopoRegions(pMesh m,
+SimMeshEntInfo::MixedRgnClass SimMeshEntInfo::readMixedTopoRegions(
       LO numTets, LO numHexs,
       LO numWedges, LO numPyramids) {
 
-    EntClass tet;
-    const auto vtxPerTet = 4;
-    tet.verts = HostWrite<LO>(numTets*vtxPerTet);
-    tet.id = HostWrite<LO>(numTets);
-    tet.dim = HostWrite<I8>(numTets);
-    auto tetIdx = 0;
+  EntClass tet;
+  const auto vtxPerTet = 4;
+  tet.verts = HostWrite<LO>(numTets*vtxPerTet);
+  tet.id = HostWrite<LO>(numTets);
+  tet.dim = HostWrite<I8>(numTets);
+  auto tetIdx = 0;
 
-    EntClass hex;
-    const auto vtxPerHex = 8;
-    hex.verts = HostWrite<LO>(numHexs*vtxPerHex);
-    hex.id = HostWrite<LO>(numHexs);
-    hex.dim = HostWrite<I8>(numHexs);
-    auto hexIdx = 0;
+  EntClass hex;
+  const auto vtxPerHex = 8;
+  hex.verts = HostWrite<LO>(numHexs*vtxPerHex);
+  hex.id = HostWrite<LO>(numHexs);
+  hex.dim = HostWrite<I8>(numHexs);
+  auto hexIdx = 0;
 
-    EntClass wedge;
-    const auto vtxPerWedge = 6;
-    wedge.verts = HostWrite<LO>(numWedges*vtxPerWedge);
-    wedge.id = HostWrite<LO>(numWedges);
-    wedge.dim = HostWrite<I8>(numWedges);
-    auto wedgeIdx = 0;
+  EntClass wedge;
+  const auto vtxPerWedge = 6;
+  wedge.verts = HostWrite<LO>(numWedges*vtxPerWedge);
+  wedge.id = HostWrite<LO>(numWedges);
+  wedge.dim = HostWrite<I8>(numWedges);
+  auto wedgeIdx = 0;
 
-    EntClass pyramid;
-    const auto vtxPerPyramid = 5;
-    pyramid.verts = HostWrite<LO>(numPyramids*vtxPerPyramid);
-    pyramid.id = HostWrite<LO>(numPyramids);
-    pyramid.dim = HostWrite<I8>(numPyramids);
-    auto pyramidIdx = 0;
+  EntClass pyramid;
+  const auto vtxPerPyramid = 5;
+  pyramid.verts = HostWrite<LO>(numPyramids*vtxPerPyramid);
+  pyramid.id = HostWrite<LO>(numPyramids);
+  pyramid.dim = HostWrite<I8>(numPyramids);
+  auto pyramidIdx = 0;
 
-    RIter regions = M_regionIter(m);
-    pRegion rgn;
-    while ((rgn = (pRegion) RIter_next(regions))) {
-      if (R_topoType(rgn) == Rtet) {
-        pPList verts = R_vertices(rgn,1);
-        setVtxIds(verts, vtxPerTet, tetIdx, tet.verts);
-        tet.id[tetIdx] = classId(rgn);
-        tet.dim[tetIdx] = classType(rgn);
-        tetIdx++;
-      }
-      else if (R_topoType(rgn) == Rhex) {
-        pPList verts = R_vertices(rgn,1);
-        setVtxIds(verts, vtxPerHex, hexIdx, hex.verts);
-        hex.id[hexIdx] = classId(rgn);
-        hex.dim[hexIdx] = classType(rgn);
-        hexIdx++;
-      }
-      else if (R_topoType(rgn) == Rwedge) {
-        pPList verts = R_vertices(rgn,1);
-        setVtxIds(verts, vtxPerWedge, wedgeIdx, wedge.verts);
-        wedge.id[wedgeIdx] = classId(rgn);
-        wedge.dim[wedgeIdx] = classType(rgn);
-        wedgeIdx++;
-      }
-      else if (R_topoType(rgn) == Rpyramid) {
-        pPList verts = R_vertices(rgn,1);
-        setVtxIds(verts, vtxPerPyramid, pyramidIdx, pyramid.verts);
-        pyramid.id[pyramidIdx] = classId(rgn);
-        pyramid.dim[pyramidIdx] = classType(rgn);
-        pyramidIdx++;
-      }
-      else {
-        Omega_h_fail ("Region is not tet, hex, wedge, or pyramid \n");
-      }
-    }
-    RIter_delete(regions);
-    return MixedRgnClass({tet,hex,wedge,pyramid});
-  }
-
-  EntClass readMonoTopoRegions(pMesh m, GO numRgn, LO vtxPerRgn) {
-    assert(vtxPerRgn == 4 || vtxPerRgn == 8);
-    if(vtxPerRgn != 4 && vtxPerRgn != 8) {
-      Omega_h_fail("Mono topology 3d mesh must be all tets or all hex\n");
-    }
-
-    EntClass rgnClass;
-    rgnClass.verts = HostWrite<LO>(numRgn*vtxPerRgn);
-    rgnClass.id = HostWrite<LO>(numRgn);
-    rgnClass.dim = HostWrite<I8>(numRgn);
-
-    const auto rgnType = ( vtxPerRgn == 4 ) ? Rtet : Rhex;
-
-    RIter regions = M_regionIter(m);
-    pRegion rgn;
-    int rgnIdx = 0;
-    while ((rgn = (pRegion) RIter_next(regions))) {
-      assert(R_topoType(rgn) == rgnType);
+  int numRegions = mR.size();
+  pRegion rgn;
+  for (int i = 0; i < numRegions; i++) {
+    rgn = mR[i];
+    if (R_topoType(rgn) == Rtet) {
       pPList verts = R_vertices(rgn,1);
-      setVtxIds(verts, vtxPerRgn, rgnIdx, rgnClass.verts);
-      rgnClass.id[rgnIdx] = classId(rgn);
-      rgnClass.dim[rgnIdx] = classType(rgn);
-      rgnIdx++;
+      setVtxIds(verts, vtxPerTet, tetIdx, tet.verts);
+      tet.id[tetIdx] = classId(rgn);
+      tet.dim[tetIdx] = classType(rgn);
+      tetIdx++;
     }
-    RIter_delete(regions);
+    else if (R_topoType(rgn) == Rhex) {
+      pPList verts = R_vertices(rgn,1);
+      setVtxIds(verts, vtxPerHex, hexIdx, hex.verts);
+      hex.id[hexIdx] = classId(rgn);
+      hex.dim[hexIdx] = classType(rgn);
+      hexIdx++;
+    }
+    else if (R_topoType(rgn) == Rwedge) {
+      pPList verts = R_vertices(rgn,1);
+      setVtxIds(verts, vtxPerWedge, wedgeIdx, wedge.verts);
+      wedge.id[wedgeIdx] = classId(rgn);
+      wedge.dim[wedgeIdx] = classType(rgn);
+      wedgeIdx++;
+    }
+    else if (R_topoType(rgn) == Rpyramid) {
+      pPList verts = R_vertices(rgn,1);
+      setVtxIds(verts, vtxPerPyramid, pyramidIdx, pyramid.verts);
+      pyramid.id[pyramidIdx] = classId(rgn);
+      pyramid.dim[pyramidIdx] = classType(rgn);
+      pyramidIdx++;
+    }
+    else {
+      Omega_h_fail ("Region is not tet, hex, wedge, or pyramid \n");
+    }
+  }
+  return MixedRgnClass({tet,hex,wedge,pyramid});
+}
 
-    return rgnClass;
+SimMeshEntInfo::EntClass SimMeshEntInfo::readMonoTopoRegions(GO numRgn, LO vtxPerRgn) {
+  assert(vtxPerRgn == 4 || vtxPerRgn == 8);
+  if(vtxPerRgn != 4 && vtxPerRgn != 8) {
+    Omega_h_fail("Mono topology 3d mesh must be all tets or all hex\n");
   }
 
+  EntClass rgnClass;
+  rgnClass.verts = HostWrite<LO>(numRgn*vtxPerRgn);
+  rgnClass.id = HostWrite<LO>(numRgn);
+  rgnClass.dim = HostWrite<I8>(numRgn);
 
-  private:
-  SimMeshEntInfo();
-  int getMaxDim(std::array<int,4> numEnts) {
-    int max_dim;
-    if (numEnts[3]) {
-      max_dim = 3;
-    } else if (numEnts[2]) {
-      max_dim = 2;
-    } else if (numEnts[1]) {
-      max_dim = 1;
-    } else {
-      Omega_h_fail("There were no Elements of dimension higher than zero!\n");
-    }
-    return max_dim;
+  const auto rgnType = ( vtxPerRgn == 4 ) ? Rtet : Rhex;
+  pRegion rgn;
+  int rgnIdx = 0;
+  for (int i = 0; i < mR.size(); i++) {
+    rgn = mR[i];
+    assert(R_topoType(rgn) == rgnType);
+    pPList verts = R_vertices(rgn,1);
+    setVtxIds(verts, vtxPerRgn, rgnIdx, rgnClass.verts);
+    rgnClass.id[rgnIdx] = classId(rgn);
+    rgnClass.dim[rgnIdx] = classType(rgn);
+    rgnIdx++;
   }
-}; //end SimMeshEntInfo
+  return rgnClass;
+}
 
-void readMixed_internal(pMesh m, MixedMesh* mesh, SimMeshInfo info) {
+int SimMeshEntInfo::getMaxDim(std::array<int,4> numEnts) {
+  int max_dim;
+  if (numEnts[3]) {
+    max_dim = 3;
+  } else if (numEnts[2]) {
+    max_dim = 2;
+  } else if (numEnts[1]) {
+    max_dim = 1;
+  } else {
+    Omega_h_fail("There were no Elements of dimension higher than zero!\n");
+  }
+  return max_dim;
+}
+
+std::vector <pVertex> getMeshVertices(pMesh m) {
+  std::vector <pVertex> v;
+  
+  VIter vertices = M_vertexIter(m);
+  pVertex vtx;
+  while ((vtx = (pVertex) VIter_next(vertices))) {
+    v.push_back(vtx);
+  }
+  VIter_delete(vertices);
+  
+  return v;
+}
+
+std::vector <pEdge> getMeshEdges(pMesh m) {
+  std::vector <pEdge> e;
+  
+  EIter edges = M_edgeIter(m);
+  pEdge edge;
+  while ((edge = (pEdge) EIter_next(edges))) {
+    e.push_back(edge);
+  }
+  EIter_delete(edges);
+  
+  return e;
+}
+
+std::vector <pFace> getMeshFaces (pMesh m) {
+  std::vector <pFace> f;
+  
+  FIter faces = M_faceIter(m);
+  pFace face;
+  while ((face = (pFace) FIter_next(faces))) {
+    f.push_back(face);
+  }
+  FIter_delete(faces);
+
+  return f;
+}
+
+std::vector <pRegion> getMeshRegions (pMesh m) {
+  std::vector <pRegion> r;
+
+  RIter regions = M_regionIter(m);
+  pRegion rgn;
+  while ((rgn = (pRegion) RIter_next(regions))) {
+    r.push_back(rgn);
+  }
+  RIter_delete(regions);
+ 
+  return r;
+}
+
+void setEntToMesh(Mesh* mesh, SimMeshEntInfo simEnts, pMeshNex numbering, SimMeshInfo info)
+{
+  int numVtx = simEnts.mV.size();
+  mesh->set_dim(simEnts.maxDim);
+  if (info.is_simplex) {
+    mesh->set_family(OMEGA_H_SIMPLEX);
+  } else if (info.is_hypercube){
+    mesh->set_family(OMEGA_H_HYPERCUBE);
+  }
+
+  //process verts
+  auto vtxInfo = simEnts.readVerts(numbering);
+  mesh->set_verts(numVtx);
+  mesh->add_coords(vtxInfo.coords.write());
+  mesh->add_tag<ClassId>(0, "class_id", 1,
+      Read<ClassId>(vtxInfo.id.write()));
+  mesh->add_tag<I8>(0, "class_dim", 1,
+      Read<I8>(vtxInfo.dim.write()));
+  if(simEnts.hasNumbering) {
+    mesh->add_tag<LO>(0, "simNumbering", 1,
+        Read<LO>(vtxInfo.numbering.write()));
+  }
+
+  //process edges
+  auto edges = simEnts.readEdges();
+  auto ev2v = Read<LO>(edges.verts.write());
+  mesh->set_ents(1, Adj(ev2v));
+  mesh->add_tag<ClassId>(1, "class_id", 1,
+                Read<ClassId>(edges.id.write()));
+  mesh->add_tag<I8>(1, "class_dim", 1,
+                    Read<I8>(edges.dim.write()));
+
+  //process faces
+  if(info.is_simplex) {
+    const auto vtxPerTri = 3;
+    auto entClass = simEnts.readMonoTopoFaces(info.count_tri, vtxPerTri);
+    auto edge2vert = mesh->get_adj(1, 0);
+    auto vert2edge = mesh->ask_up(0, 1);
+    auto tri2verts = Read<LO>(entClass.verts.write());
+    auto down = reflect_down(tri2verts, edge2vert.ab2b, vert2edge,
+                             OMEGA_H_SIMPLEX, 2, 1);
+    mesh->set_ents(2, down);
+    mesh->add_tag<ClassId>(2, "class_id", 1,
+                           Read<ClassId>(entClass.id.write()));
+    mesh->add_tag<I8>(2, "class_dim", 1,
+                      Read<I8>(entClass.dim.write()));
+  } else { // hypercube
+    const auto vtxPerQuad = 4;
+    auto entClass = simEnts.readMonoTopoFaces(info.count_quad, vtxPerQuad);
+    auto edge2vert = mesh->get_adj(1, 0);
+    auto vert2edge = mesh->ask_up(0, 1);
+    auto quad2verts = Read<LO>(entClass.verts.write());
+    auto down = reflect_down(quad2verts, edge2vert.ab2b, vert2edge,
+                        OMEGA_H_HYPERCUBE, 2, 1);
+    mesh->set_ents(2, down);
+    mesh->add_tag<ClassId>(2, "class_id", 1,
+                           Read<ClassId>(entClass.id.write()));
+    mesh->add_tag<I8>(2, "class_dim", 1,
+                      Read<I8>(entClass.dim.write()));
+  }
+
+  //process regions
+  if(simEnts.maxDim == 2)
+    return; //there are no regions
+
+  if(info.is_simplex) {
+    const auto vtxPerTet = 4;
+    auto entClass = simEnts.readMonoTopoRegions(info.count_tet, vtxPerTet);
+    auto tri2vert = mesh->ask_down(2, 0);
+    auto vert2tri = mesh->ask_up(0, 2);
+    auto tet2verts = Read<LO>(entClass.verts.write());
+    auto down = reflect_down(tet2verts, tri2vert.ab2b, vert2tri,
+        OMEGA_H_SIMPLEX, 3, 2);
+    mesh->set_ents(3, down);
+    mesh->template add_tag<ClassId>(3, "class_id", 1,
+        Read<ClassId>(entClass.id.write()));
+    mesh->template add_tag<I8>(3, "class_dim", 1,
+        Read<I8>(entClass.dim.write()));
+  } else { //hypercube
+    const auto vtxPerHex = 8;
+    auto entClass = simEnts.readMonoTopoRegions(info.count_hex, vtxPerHex);
+    auto quad2vert = mesh->ask_down(2, 0);
+    auto vert2quad = mesh->ask_up(0, 2);
+    auto hex2verts = Read<LO>(entClass.verts.write());
+    auto down = reflect_down(hex2verts, quad2vert.ab2b, vert2quad,
+        OMEGA_H_HYPERCUBE, 3, 2);
+    mesh->set_ents(3, down);
+    mesh->template add_tag<ClassId>(3, "class_id", 1,
+        Read<ClassId>(entClass.id.write()));
+    mesh->template add_tag<I8>(3, "class_dim", 1,
+        Read<I8>(entClass.dim.write()));
+  }
+}
+
+void readMixed_internal(SimMesh simMesh, MixedMesh* mesh, SimMeshInfo info) {
   assert(!info.is_simplex && !info.is_hypercube);
   if(info.is_simplex || info.is_hypercube) {
       Omega_h_fail("Attempting to use the mixed mesh reader for a mono topology"
                    "mesh (family = simplex|hypercube)!\n");
   }
 
-  const int numVtx = M_numVertices(m);
-  const int numEdges = M_numEdges(m);
-  const int numFaces = M_numFaces(m);
-  const int numRegions = M_numRegions(m);
-
   const bool hasNumbering = false;
 
-  SimMeshEntInfo simEnts({{numVtx,numEdges,numFaces,numRegions}}, hasNumbering);
+  SimMeshEntInfo simEnts(simMesh,  hasNumbering);
   mesh->set_dim(simEnts.maxDim);
+  const int numVtx = simEnts.mV.size();
 
   // process verts
-  auto vtxInfo = simEnts.readVerts(m,nullptr);
+  auto vtxInfo = simEnts.readVerts(nullptr);
   mesh->set_verts_type(numVtx);
   mesh->add_coords_mix(vtxInfo.coords.write());
   mesh->add_tag<ClassId>(Topo_type::vertex, "class_id", 1,
@@ -437,7 +531,7 @@ void readMixed_internal(pMesh m, MixedMesh* mesh, SimMeshInfo info) {
                     Read<I8>(vtxInfo.dim.write()));
 
   // process edges
-  auto edges = simEnts.readEdges(m);
+  auto edges = simEnts.readEdges();
   auto ev2v = Read<LO>(edges.verts.write());
   mesh->set_ents(Topo_type::edge, Topo_type::vertex, Adj(ev2v));
   mesh->add_tag<ClassId>(Topo_type::edge, "class_id", 1,
@@ -446,7 +540,7 @@ void readMixed_internal(pMesh m, MixedMesh* mesh, SimMeshInfo info) {
                     Read<I8>(edges.dim.write()));
 
   //process faces
-  auto mixedFaceClass = simEnts.readMixedFaces(m, info.count_tri, info.count_quad);
+  auto mixedFaceClass = simEnts.readMixedFaces(info.count_tri, info.count_quad);
   auto edge2vert = mesh->get_adj(Topo_type::edge, Topo_type::vertex);
   auto vert2edge = mesh->ask_up(Topo_type::vertex, Topo_type::edge);
 
@@ -474,7 +568,7 @@ void readMixed_internal(pMesh m, MixedMesh* mesh, SimMeshInfo info) {
   if(simEnts.maxDim == 2)
     return; //there are no regions
 
-  auto mixedRgnClass = simEnts.readMixedTopoRegions(m,
+  auto mixedRgnClass = simEnts.readMixedTopoRegions(
       info.count_tet, info.count_hex,
       info.count_wedge, info.count_pyramid);
   auto tri2vert = mesh->ask_down(Topo_type::triangle, Topo_type::vertex);
@@ -529,110 +623,17 @@ void readMixed_internal(pMesh m, MixedMesh* mesh, SimMeshInfo info) {
       Read<I8>(mixedRgnClass.pyramid.dim.write()));
 }
 
-void read_internal(pMesh m, Mesh* mesh, pMeshNex numbering, SimMeshInfo info) {
+void read_internal(SimMesh m, Mesh* mesh, pMeshNex numbering, SimMeshInfo info) {
   assert(info.is_simplex || info.is_hypercube);
   if(!info.is_simplex && !info.is_hypercube) {
       Omega_h_fail("Attempting to use the mono topology reader for a mixed"
                    "mesh (family = mixed)!\n");
   }
 
-  const int numVtx = M_numVertices(m);
-  const int numEdges = M_numEdges(m);
-  const int numFaces = M_numFaces(m);
-  const int numRegions = M_numRegions(m);
-
   const bool hasNumbering = (numbering != NULL);
 
-  SimMeshEntInfo simEnts({{numVtx,numEdges,numFaces,numRegions}}, hasNumbering);
-  mesh->set_dim(simEnts.maxDim);
-  if (info.is_simplex) {
-    mesh->set_family(OMEGA_H_SIMPLEX);
-  } else if (info.is_hypercube){
-    mesh->set_family(OMEGA_H_HYPERCUBE);
-  }
-
-  //process verts
-  auto vtxInfo = simEnts.readVerts(m,numbering);
-  mesh->set_verts(numVtx);
-  mesh->add_coords(vtxInfo.coords.write());
-  mesh->add_tag<ClassId>(0, "class_id", 1,
-      Read<ClassId>(vtxInfo.id.write()));
-  mesh->add_tag<I8>(0, "class_dim", 1,
-      Read<I8>(vtxInfo.dim.write()));
-  if(hasNumbering) {
-    mesh->add_tag<LO>(0, "simNumbering", 1,
-        Read<LO>(vtxInfo.numbering.write()));
-  }
-
-  //process edges
-  auto edges = simEnts.readEdges(m);
-  auto ev2v = Read<LO>(edges.verts.write());
-  mesh->set_ents(1, Adj(ev2v));
-  mesh->add_tag<ClassId>(1, "class_id", 1,
-                Read<ClassId>(edges.id.write()));
-  mesh->add_tag<I8>(1, "class_dim", 1,
-                    Read<I8>(edges.dim.write()));
-
-  //process faces
-  if(info.is_simplex) {
-    const auto vtxPerTri = 3;
-    auto entClass = simEnts.readMonoTopoFaces(m, info.count_tri, vtxPerTri);
-    auto edge2vert = mesh->get_adj(1, 0);
-    auto vert2edge = mesh->ask_up(0, 1);
-    auto tri2verts = Read<LO>(entClass.verts.write());
-    auto down = reflect_down(tri2verts, edge2vert.ab2b, vert2edge,
-                             OMEGA_H_SIMPLEX, 2, 1);
-    mesh->set_ents(2, down);
-    mesh->add_tag<ClassId>(2, "class_id", 1,
-                           Read<ClassId>(entClass.id.write()));
-    mesh->add_tag<I8>(2, "class_dim", 1,
-                      Read<I8>(entClass.dim.write()));
-  } else { // hypercube
-    const auto vtxPerQuad = 4;
-    auto entClass = simEnts.readMonoTopoFaces(m, info.count_quad, vtxPerQuad);
-    auto edge2vert = mesh->get_adj(1, 0);
-    auto vert2edge = mesh->ask_up(0, 1);
-    auto quad2verts = Read<LO>(entClass.verts.write());
-    auto down = reflect_down(quad2verts, edge2vert.ab2b, vert2edge,
-                        OMEGA_H_HYPERCUBE, 2, 1);
-    mesh->set_ents(2, down);
-    mesh->add_tag<ClassId>(2, "class_id", 1,
-                           Read<ClassId>(entClass.id.write()));
-    mesh->add_tag<I8>(2, "class_dim", 1,
-                      Read<I8>(entClass.dim.write()));
-  }
-
-  //process regions
-  if(simEnts.maxDim == 2)
-    return; //there are no regions
-
-  if(info.is_simplex) {
-    const auto vtxPerTet = 4;
-    auto entClass = simEnts.readMonoTopoRegions(m, info.count_tet, vtxPerTet);
-    auto tri2vert = mesh->ask_down(2, 0);
-    auto vert2tri = mesh->ask_up(0, 2);
-    auto tet2verts = Read<LO>(entClass.verts.write());
-    auto down = reflect_down(tet2verts, tri2vert.ab2b, vert2tri,
-        OMEGA_H_SIMPLEX, 3, 2);
-    mesh->set_ents(3, down);
-    mesh->template add_tag<ClassId>(3, "class_id", 1,
-        Read<ClassId>(entClass.id.write()));
-    mesh->template add_tag<I8>(3, "class_dim", 1,
-        Read<I8>(entClass.dim.write()));
-  } else { //hypercube
-    const auto vtxPerHex = 8;
-    auto entClass = simEnts.readMonoTopoRegions(m, info.count_hex, vtxPerHex);
-    auto quad2vert = mesh->ask_down(2, 0);
-    auto vert2quad = mesh->ask_up(0, 2);
-    auto hex2verts = Read<LO>(entClass.verts.write());
-    auto down = reflect_down(hex2verts, quad2vert.ab2b, vert2quad,
-        OMEGA_H_HYPERCUBE, 3, 2);
-    mesh->set_ents(3, down);
-    mesh->template add_tag<ClassId>(3, "class_id", 1,
-        Read<ClassId>(entClass.id.write()));
-    mesh->template add_tag<I8>(3, "class_dim", 1,
-        Read<I8>(entClass.dim.write()));
-  }
+  SimMeshEntInfo simEnts(m, hasNumbering);
+  setEntToMesh(mesh, simEnts, numbering, info);
 }
  
 MixedMesh readMixedImpl(filesystem::path const& mesh_fname,
@@ -647,10 +648,16 @@ MixedMesh readMixedImpl(filesystem::path const& mesh_fname,
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
   pMesh m = M_load(mesh_fname.c_str(), g, p);
-  auto simMeshInfo = getSimMeshInfo(m);
+
+  std::vector <pVertex> mV = getMeshVertices(m); 
+  std::vector <pEdge> mE = getMeshEdges(m);
+  std::vector <pFace> mF = getMeshFaces(m); 
+  std::vector <pRegion> mR = getMeshRegions(m);
+  SimMesh simMesh(mV,mE,mF,mR);
+  auto simMeshInfo = getSimMeshInfo(simMesh);
   auto mesh = MixedMesh(comm->library());
   mesh.set_comm(comm);
-  meshsim::readMixed_internal(m, &mesh, simMeshInfo);
+  meshsim::readMixed_internal(simMesh, &mesh, simMeshInfo);
   M_release(m);
   GM_release(g);
 #ifdef OMEGA_H_USE_SIMDISCRETE
@@ -671,13 +678,20 @@ Mesh readImpl(filesystem::path const& mesh_fname, filesystem::path const& mdl_fn
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
   pMesh m = M_load(mesh_fname.c_str(), g, p);
-  auto simMeshInfo = getSimMeshInfo(m);
+
+  std::vector <pVertex> mV = getMeshVertices(m); 
+  std::vector <pEdge> mE = getMeshEdges(m);
+  std::vector <pFace> mF = getMeshFaces(m); 
+  std::vector <pRegion> mR = getMeshRegions(m);
+  SimMesh simMesh(mV,mE,mF,mR);
+
+  auto simMeshInfo = getSimMeshInfo(simMesh);
   const bool hasNumbering = (numbering_fname.native() != std::string(""));
   pMeshNex numbering = hasNumbering ? MeshNex_load(numbering_fname.c_str(), m) : nullptr;
   auto mesh = Mesh(comm->library());
   mesh.set_comm(comm);
   mesh.set_parting(OMEGA_H_ELEM_BASED);
-  meshsim::read_internal(m, &mesh, numbering, simMeshInfo);
+  meshsim::read_internal(simMesh, &mesh, numbering, simMeshInfo);
   if(hasNumbering) MeshNex_delete(numbering);
   M_release(m);
   GM_release(g);
@@ -698,7 +712,14 @@ bool isMixed(filesystem::path const& mesh_fname, filesystem::path const& mdl_fna
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
   pMesh m = M_load(mesh_fname.c_str(), g, p);
-  auto simMeshInfo = getSimMeshInfo(m);
+  
+  std::vector <pVertex> mV = getMeshVertices(m); 
+  std::vector <pEdge> mE = getMeshEdges(m);
+  std::vector <pFace> mF = getMeshFaces(m); 
+  std::vector <pRegion> mR = getMeshRegions(m);
+  SimMesh simMesh(mV,mE,mF,mR);
+
+  auto simMeshInfo = getSimMeshInfo(simMesh);
   M_release(m);
   GM_release(g);
 #ifdef OMEGA_H_USE_SIMDISCRETE
@@ -716,11 +737,13 @@ Mesh read(filesystem::path const& mesh_fname, filesystem::path const& mdl_fname,
 
 Mesh read(filesystem::path const& mesh_fname, filesystem::path const& mdl_fname,
     CommPtr comm) {
+  std::cout << "Here in Read \n";
   return readImpl(mesh_fname, mdl_fname, std::string(""), comm);
 }
 
 MixedMesh readMixed(filesystem::path const& mesh_fname, filesystem::path const& mdl_fname,
     CommPtr comm) {
+  std::cout << "Here in read mixed\n";
   return readMixedImpl(mesh_fname, mdl_fname, comm);
 }
 

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -156,8 +156,6 @@ SimMeshEntInfo::SimMeshEntInfo(const SimMesh& simMesh, bool hasNumbering_in) {
   int numR = mR.size(); 
   std::array<int,4> numEnts = {numV, numE, numF, numR};
   maxDim = getMaxDim(numEnts);
-  std::cout << "Max Dimension = " << maxDim << "\n";
-  std::cout << "Mesh is " <<(maxDim==2?"2D":"3D") << "\n";
 }
 
 SimMeshEntInfo::VertexInfo SimMeshEntInfo::readVerts(pMeshNex numbering) {
@@ -706,12 +704,8 @@ MixedMesh readMixedImpl(filesystem::path const& mesh_fname,
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
   pMesh m = M_load(mesh_fname.c_str(), g, p);
+  SimMesh simMesh(m);
 
-  std::vector <pVertex> mV = getMeshVertices(m); 
-  std::vector <pEdge> mE = getMeshEdges(m);
-  std::vector <pFace> mF = getMeshFaces(m); 
-  std::vector <pRegion> mR = getMeshRegions(m);
-  SimMesh simMesh(mV,mE,mF,mR);
   auto simMeshInfo = getSimMeshInfo(simMesh);
   auto mesh = MixedMesh(comm->library());
   mesh.set_comm(comm);
@@ -736,12 +730,7 @@ Mesh readImpl(filesystem::path const& mesh_fname, filesystem::path const& mdl_fn
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
   pMesh m = M_load(mesh_fname.c_str(), g, p);
-
-  std::vector <pVertex> mV = getMeshVertices(m); 
-  std::vector <pEdge> mE = getMeshEdges(m);
-  std::vector <pFace> mF = getMeshFaces(m); 
-  std::vector <pRegion> mR = getMeshRegions(m);
-  SimMesh simMesh(mV,mE,mF,mR);
+  SimMesh simMesh(m);
 
   auto simMeshInfo = getSimMeshInfo(simMesh);
   const bool hasNumbering = (numbering_fname.native() != std::string(""));
@@ -770,12 +759,7 @@ bool isMixed(filesystem::path const& mesh_fname, filesystem::path const& mdl_fna
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
   pMesh m = M_load(mesh_fname.c_str(), g, p);
-  
-  std::vector <pVertex> mV = getMeshVertices(m); 
-  std::vector <pEdge> mE = getMeshEdges(m);
-  std::vector <pFace> mF = getMeshFaces(m); 
-  std::vector <pRegion> mR = getMeshRegions(m);
-  SimMesh simMesh(mV,mE,mF,mR);
+  SimMesh simMesh(m);
 
   auto simMeshInfo = getSimMeshInfo(simMesh);
   M_release(m);
@@ -795,13 +779,11 @@ Mesh read(filesystem::path const& mesh_fname, filesystem::path const& mdl_fname,
 
 Mesh read(filesystem::path const& mesh_fname, filesystem::path const& mdl_fname,
     CommPtr comm) {
-  std::cout << "Here in Read \n";
   return readImpl(mesh_fname, mdl_fname, std::string(""), comm);
 }
 
 MixedMesh readMixed(filesystem::path const& mesh_fname, filesystem::path const& mdl_fname,
     CommPtr comm) {
-  std::cout << "Here in read mixed\n";
   return readMixedImpl(mesh_fname, mdl_fname, comm);
 }
 

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -36,6 +36,41 @@ SimMesh::SimMesh(std::vector <pVertex> vertices, std::vector <pEdge> edges,
   mR = regions;
 }
 
+SimMesh::SimMesh(pMesh m) {
+
+  // Regions
+  RIter regions = M_regionIter(m);
+  pRegion rgn;
+  while ((rgn = (pRegion) RIter_next(regions))) {
+    mR.push_back(rgn);
+  }
+  RIter_delete(regions);
+
+  // Faces
+  FIter faces = M_faceIter(m);
+  pFace face;
+  while ((face = (pFace) FIter_next(faces))) {
+    mF.push_back(face);
+  }
+  FIter_delete(faces);
+
+  // Edges
+  EIter edges = M_edgeIter(m);
+  pEdge edge;
+  while ((edge = (pEdge) EIter_next(edges))) {
+    mE.push_back(edge);
+  }
+  EIter_delete(edges);
+  
+  // Vertices
+  VIter vertices = M_vertexIter(m);
+  pVertex vert;
+  while ((vert = (pVertex) VIter_next(vertices))) {
+    mV.push_back(vert);
+  }
+  VIter_delete(vertices);
+}
+
 SimMeshInfo getSimMeshInfo(const SimMesh& mesh) {
   SimMeshInfo info = {0,0,0,0,0,0,false,false};
 
@@ -142,11 +177,14 @@ SimMeshEntInfo::VertexInfo SimMeshEntInfo::readVerts(pMeshNex numbering) {
     V_coord(vtx,xyz);
      
      // Convert coordinates from 3d cylindrical to 2d cartesian
-     double r = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1]);
-     xyz[0] = r;  // x = r =sqrt(x^2 + y^2)
-     xyz[1] = xyz[2];  // y = z  
-     xyz[2] = 0.0;  // z = 0.0
-    
+     if( maxDim == 2)
+     {
+       double r = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1]);
+       xyz[0] = r;  // x = r =sqrt(x^2 + y^2)
+       xyz[1] = xyz[2];  // y = z  
+       xyz[2] = 0.0;  // z = 0.0
+    }
+
     if( maxDim < 3 && xyz[2] != 0 )
       Omega_h_fail("The z coordinate must be zero for a 2d mesh!\n");
     for(int j=0; j<maxDim; j++) {

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -171,18 +171,29 @@ SimMeshEntInfo::VertexInfo SimMeshEntInfo::readVerts(pMeshNex numbering) {
 
   pVertex vtx;
   LO v = 0;
+
+  // Check if transformation data is attached on mesh vertices.
+  bool coordTransformationOn = false;
+  pMeshDataId tData = MD_lookupMeshDataId("tCoord");
+  if (EN_getDataPtr(mV[0], tData, NULL))
+  {
+    coordTransformationOn = true;
+    std::cout << "Coordinate Transformation = ON\n";
+  }
+
   for (int i = 0; i <numVtx; i++) {
     vtx = mV[i];
     double xyz[3];
     V_coord(vtx,xyz);
      
-     // Convert coordinates from 3d cylindrical to 2d cartesian
-     if( maxDim == 2)
+     // Convert coordinates from 3d cartesian to 2d cylindrical
+     if(coordTransformationOn)
      {
-       double r = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1]);
-       xyz[0] = r;  // x = r =sqrt(x^2 + y^2)
-       xyz[1] = xyz[2];  // y = z  
-       xyz[2] = 0.0;  // z = 0.0
+       double* rzphi;  // R,Z,Phi
+       EN_getDataPtr((pEntity)vtx, tData, (void**)&rzphi);
+       xyz[0] = rzphi[0];
+       xyz[1] = rzphi[1];   
+       xyz[2] = 0.0;  
     }
 
     if( maxDim < 3 && xyz[2] != 0 )

--- a/src/Omega_h_meshsim.hpp
+++ b/src/Omega_h_meshsim.hpp
@@ -39,6 +39,7 @@ struct SimMesh{
   std::vector <pRegion> mR; 
   SimMesh(std::vector <pVertex> vertices, std::vector <pEdge> edges, 
           std::vector <pFace> faces, std::vector <pRegion> regions);
+  SimMesh(pMesh m);
 };
 
 SimMeshInfo getSimMeshInfo(const SimMesh& mesh);

--- a/src/Omega_h_meshsim.hpp
+++ b/src/Omega_h_meshsim.hpp
@@ -1,0 +1,113 @@
+#ifndef OMEGA_H_MESHSIM_HPP
+#define OMEGA_H_MESHSIM_HPP
+
+#include "Omega_h_file.hpp"
+#include "Omega_h_build.hpp"
+#include "Omega_h_class.hpp"
+#include "Omega_h_map.hpp"
+#include "Omega_h_vector.hpp"
+#include "Omega_h_mesh.hpp"
+#include "Omega_h_mixedMesh.hpp"
+#include "Omega_h_adj.hpp"
+
+#include "MeshSim.h" // required to load GeomSim models in '.smd' files
+#include "SimUtil.h"
+#ifdef OMEGA_H_USE_SIMDISCRETE
+#include "SimDiscrete.h"  // required to load discrete models in '.smd' files
+#endif
+
+namespace Omega_h {
+
+namespace meshsim {
+
+struct SimMeshInfo {
+  int count_tet;
+  int count_hex;
+  int count_wedge;
+  int count_pyramid;
+  int count_tri;
+  int count_quad;
+  bool is_simplex;
+  bool is_hypercube;
+};
+
+
+struct SimMesh{
+  std::vector <pVertex> mV; 
+  std::vector <pEdge> mE; 
+  std::vector <pFace> mF; 
+  std::vector <pRegion> mR; 
+  SimMesh(std::vector <pVertex> vertices, std::vector <pEdge> edges, 
+          std::vector <pFace> faces, std::vector <pRegion> regions);
+};
+
+SimMeshInfo getSimMeshInfo(pMesh m);
+
+struct SimMeshEntInfo {
+  int maxDim;
+  bool hasNumbering;
+
+  std::vector <pVertex> mV;  // mesh vertices
+  std::vector <pEdge> mE;  // mesh edges
+  std::vector <pFace> mF;  // mesh faces
+  std::vector <pRegion> mR;  // mesh regions
+
+  SimMeshEntInfo(const SimMesh& simMesh, bool hasNumbering_in);
+
+  struct EntClass {
+    HostWrite<LO> id;
+    HostWrite<I8> dim;
+    HostWrite<LO> verts;
+  };
+
+  struct VertexInfo {
+    HostWrite<Real> coords;
+    HostWrite<LO> id;
+    HostWrite<I8> dim;
+    HostWrite<LO> numbering;
+  };
+
+  VertexInfo readVerts(pMeshNex numbering);
+  void setVtxIds(pPList listVerts, const int vtxPerEnt, const int entIdx, HostWrite<LO>& verts);
+  EntClass readEdges();
+
+  struct MixedFaceClass {
+    EntClass tri;
+    EntClass quad;
+  };
+
+  MixedFaceClass readMixedFaces(GO count_tri, GO count_quad);
+  EntClass readMonoTopoFaces(GO numFaces, LO vtxPerFace);
+  
+  struct MixedRgnClass {
+    EntClass tet;
+    EntClass hex;
+    EntClass wedge;
+    EntClass pyramid;
+  };
+
+  MixedRgnClass readMixedTopoRegions(
+      LO numTets, LO numHexs,
+      LO numWedges, LO numPyramids);
+
+  EntClass readMonoTopoRegions(GO numRgn, LO vtxPerRgn);
+
+  private:
+  SimMeshEntInfo();
+  int getMaxDim(std::array<int,4> numEnts);
+};
+
+std::vector <pVertex> getMeshVertices(pMesh m);
+std::vector <pEdge> getMeshEdges(pMesh m);
+std::vector <pFace> getMeshFaces(pMesh m);
+std::vector <pRegion> getMeshRegions(pMesh m);
+void setEntToMesh(Mesh* mesh, SimMeshEntInfo simEnts, pMeshNex numbering, SimMeshInfo info);
+void readMixed_internal(SimMesh simMesh, MixedMesh* mesh, SimMeshInfo info);
+void read_internal(SimMesh simMesh, Mesh* mesh, pMeshNex numbering, SimMeshInfo info);
+
+}  // namespace meshsim
+
+}  // end namespace Omega_h
+
+#endif
+

--- a/src/Omega_h_meshsim.hpp
+++ b/src/Omega_h_meshsim.hpp
@@ -41,7 +41,7 @@ struct SimMesh{
           std::vector <pFace> faces, std::vector <pRegion> regions);
 };
 
-SimMeshInfo getSimMeshInfo(pMesh m);
+SimMeshInfo getSimMeshInfo(const SimMesh& mesh);
 
 struct SimMeshEntInfo {
   int maxDim;


### PR DESCRIPTION
Simmetrix mesh to Omega_h mesh conversion function required Simmetrix mesh to be passed as an argument. For fusion applications (specifically stellarator cases), we have  bunch of 2D poloidal planes on a single mesh and we want to create a copy of Omega_h mesh for each individual plane.  To deal with it, instead of passing mesh directly  to functions, I have modified those functions to take in vectors of mesh entities. The top level conversion calls are still the same though, and I only changed internal 
functions and made those functions accessible for use and added a new header file Omega_h_meshsim.hpp. The pull request contains following changes:

1. Added a struct SimMesh that can take in either Simmetrix mesh (pMesh) directly or 4 vectors of mesh entities (vertices, edges, faces, regions).

2. The function getSimMeshInfo uses SimMesh as input instead of pMesh. 
3. Few additions  in constructor of SimMeshEntInfo to reflect above two additions.
4. Since the 2D Omegah meshes require the z-coordinate to be zero, a coordinate transformation option is added. This will do transformation from 3D Cartesian (X-Y-Z) to 2D cylindrical plane (R-Z). The toroidal direction phi is set to zero.
5. Added the following function to header file, so It could be used directly in STOMMS. 
```
void write_mesh(adios2::IO &io, adios2::Engine & writer, Mesh* mesh, std::string pref); 
```