### PR TITLE
Multi sim mesh planes

### DIFF
--- a/src/Omega_h_file.hpp
+++ b/src/Omega_h_file.hpp
@@ -13,7 +13,9 @@
 #include <Omega_h_mixedMesh.hpp>
 #include <Omega_h_tag.hpp>
 
+#ifdef OMEGA_H_USE_SIMMODSUITE
 #include "MeshSim.h"
+#endif
 
 namespace Omega_h {
 

--- a/src/Omega_h_file.hpp
+++ b/src/Omega_h_file.hpp
@@ -13,6 +13,8 @@
 #include <Omega_h_mixedMesh.hpp>
 #include <Omega_h_tag.hpp>
 
+#include "MeshSim.h"
+
 namespace Omega_h {
 
 OMEGA_H_DLL Mesh read_mesh_file(filesystem::path const& path, CommPtr comm);
@@ -38,7 +40,14 @@ namespace meshsim {
  * @param[in] model path to Simmetrix GeomSim .smd model file
  */
 bool isMixed(filesystem::path const& mesh, filesystem::path const& model);
-
+/**
+ * Convert a serial Simmetrix sms mesh classified on the specified model to an
+ * Omega_h mesh instance.
+ * @param[in] pointer to Simmetrix mesh instance (pMesh)
+ * @param[in] numbering path to Simmetrix MeshNex .nex numbering file
+ * @param[in] comm path to Omega_h communicator instance
+ */
+Mesh read(pMesh* m, filesystem::path const& numbering_fname, CommPtr comm);
 /**
  * Convert a serial Simmetrix sms mesh classified on the specified model to an
  * Omega_h mesh instance.

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -660,6 +660,18 @@ MixedMesh readMixedImpl(filesystem::path const& mesh_fname,
   return mesh;
 }
 
+Mesh readMesh(pMesh* m,filesystem::path const& numbering_fname, CommPtr comm) {\
+  auto simMeshInfo = getSimMeshInfo(*m);
+  const bool hasNumbering = (numbering_fname.native() != std::string(""));
+  pMeshNex numbering = hasNumbering ? MeshNex_load(numbering_fname.c_str(), *m) : nullptr;
+  auto mesh = Mesh(comm->library());
+  mesh.set_comm(comm);
+  mesh.set_parting(OMEGA_H_ELEM_BASED);
+  meshsim::read_internal(*m, &mesh, numbering, simMeshInfo);
+  if(hasNumbering) MeshNex_delete(numbering);
+  return mesh;
+}
+
 Mesh readImpl(filesystem::path const& mesh_fname, filesystem::path const& mdl_fname,
     filesystem::path const& numbering_fname, CommPtr comm) {
   MS_init();
@@ -671,14 +683,7 @@ Mesh readImpl(filesystem::path const& mesh_fname, filesystem::path const& mdl_fn
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
   pMesh m = M_load(mesh_fname.c_str(), g, p);
-  auto simMeshInfo = getSimMeshInfo(m);
-  const bool hasNumbering = (numbering_fname.native() != std::string(""));
-  pMeshNex numbering = hasNumbering ? MeshNex_load(numbering_fname.c_str(), m) : nullptr;
-  auto mesh = Mesh(comm->library());
-  mesh.set_comm(comm);
-  mesh.set_parting(OMEGA_H_ELEM_BASED);
-  meshsim::read_internal(m, &mesh, numbering, simMeshInfo);
-  if(hasNumbering) MeshNex_delete(numbering);
+  auto mesh = readMesh(&m, numbering_fname, comm);
   M_release(m);
   GM_release(g);
 #ifdef OMEGA_H_USE_SIMDISCRETE

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -660,7 +660,7 @@ MixedMesh readMixedImpl(filesystem::path const& mesh_fname,
   return mesh;
 }
 
-Mesh readMesh(pMesh* m,filesystem::path const& numbering_fname, CommPtr comm) {\
+Mesh read(pMesh* m, filesystem::path const& numbering_fname, CommPtr comm) {
   auto simMeshInfo = getSimMeshInfo(*m);
   const bool hasNumbering = (numbering_fname.native() != std::string(""));
   pMeshNex numbering = hasNumbering ? MeshNex_load(numbering_fname.c_str(), *m) : nullptr;
@@ -683,7 +683,7 @@ Mesh readImpl(filesystem::path const& mesh_fname, filesystem::path const& mdl_fn
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
   pMesh m = M_load(mesh_fname.c_str(), g, p);
-  auto mesh = readMesh(&m, numbering_fname, comm);
+  auto mesh = read(&m, numbering_fname, comm);
   M_release(m);
   GM_release(g);
 #ifdef OMEGA_H_USE_SIMDISCRETE


### PR DESCRIPTION
This PR:
-   extracts the part of the code that uses the Simmetrix mesh instance (pMesh) from the function readImpl()
-   adds the factored out code from above to a new function read() that takes in a pointer to pMesh
-   adds the function read() written above to the header omega_h_file.hpp 