### PR TITLE
Optional argument to read coordinate transformation data attached to Simmetrix meshes

### DIFF
--- a/src/Omega_h_file.hpp
+++ b/src/Omega_h_file.hpp
@@ -48,8 +48,9 @@ bool isMixed(filesystem::path const& mesh, filesystem::path const& model);
  * @param[in] pointer to Simmetrix mesh instance (pMesh)
  * @param[in] numbering path to Simmetrix MeshNex .nex numbering file
  * @param[in] comm path to Omega_h communicator instance
+ * @param[in] optional coordinate transformation option.
  */
-Mesh read(pMesh* m, filesystem::path const& numbering_fname, CommPtr comm);
+Mesh read(pMesh* m, filesystem::path const& numbering_fname, CommPtr comm, bool transformationOn = false);
 /**
  * Convert a serial Simmetrix sms mesh classified on the specified model to an
  * Omega_h mesh instance.

--- a/src/Omega_h_file.hpp
+++ b/src/Omega_h_file.hpp
@@ -48,9 +48,10 @@ bool isMixed(filesystem::path const& mesh, filesystem::path const& model);
  * @param[in] pointer to Simmetrix mesh instance (pMesh)
  * @param[in] numbering path to Simmetrix MeshNex .nex numbering file
  * @param[in] comm path to Omega_h communicator instance
- * @param[in] optional coordinate transformation option.
+ * @param[in][optional] a pointer to pMeshDataId for coordinate transformation 
+ *                      data attached to mesh vertices.
  */
-Mesh read(pMesh* m, filesystem::path const& numbering_fname, CommPtr comm, bool transformationOn = false);
+Mesh read(pMesh* m, filesystem::path const& numbering_fname, CommPtr comm, pMeshDataId* transformedCoordId = NULL);
 /**
  * Convert a serial Simmetrix sms mesh classified on the specified model to an
  * Omega_h mesh instance.

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -163,8 +163,6 @@ struct SimMeshEntInfo {
     pVertex vtx;
     LO v = 0;
     
-    if (transformedCoordId)
-      std::cout << "Coordinate Transformation is ON \n";
     while ((vtx = (pVertex) VIter_next(vertices))) {
       double xyz[3];
       V_coord(vtx,xyz);


### PR DESCRIPTION
This PR contains:

- modified read function that has an optional argument to take in coordinate transformation data attached to Simmetrix meshes.