### PR TITLE
Set `Write<T>::use_count()` as host only function

### DIFF
--- a/src/Omega_h_array.hpp
+++ b/src/Omega_h_array.hpp
@@ -74,7 +74,7 @@ class Write {
 #endif
   void set(LO i, T value) const;
   T get(LO i) const;
-  OMEGA_H_INLINE long use_count() const;
+  long use_count() const;
   OMEGA_H_INLINE bool exists() const noexcept;
 #ifdef OMEGA_H_USE_KOKKOS
   std::string name() const;

--- a/src/Omega_h_array_kokkos.hpp
+++ b/src/Omega_h_array_kokkos.hpp
@@ -33,7 +33,7 @@ OMEGA_H_INLINE T* Write<T>::data() const noexcept {
 }
 
 template <typename T>
-OMEGA_H_INLINE long Write<T>::use_count() const {
+long Write<T>::use_count() const {
   return manager_ ? manager_.use_count() : view_.use_count();
 }
 


### PR DESCRIPTION
Solve the [issue 141](https://github.com/SCOREC/omega_h/issues/141). Since we only need to call the use_count() function from the host, we could set it as a host-only function.

PS: other usage of `use_count()` seems to be related to different functions including `std::shared_ptr<T>::use_count`, `Alloc.use_count`.