### PR TITLE
Debug OMEGA_H_CHECK warnings

### DIFF
--- a/src/Omega_h_library.cpp
+++ b/src/Omega_h_library.cpp
@@ -116,7 +116,8 @@ void Library::initialize(char const* head_desc, int* argc, char*** argv
       cmdline.add_flag("--osh-mpi-ranks-per-node", "mpi ranks per node (for CUDA+MPI)");
   mpi_ranks_flag.add_arg<int>("value");
   if (argc && argv) {
-    OMEGA_H_CHECK(cmdline.parse(world_, argc, *argv));
+    bool parse_success = cmdline.parse(world_, argc, *argv);
+    OMEGA_H_CHECK(parse_success);
   }
   bool add_filename = false;
   if (cmdline.parsed("--osh-time-with-filename")) {

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -403,7 +403,7 @@ struct SimMeshEntInfo {
     pRegion rgn;
     int rgnIdx = 0;
     while ((rgn = (pRegion) RIter_next(regions))) {
-      assert(R_topoType(rgn) == rgnType);
+      OMEGA_H_CHECK(R_topoType(rgn) == rgnType);
       pPList verts = R_vertices(rgn,1);
       setVtxIds(verts, vtxPerRgn, rgnIdx, rgnClass.verts);
       rgnClass.id[rgnIdx] = classId(rgn);


### PR DESCRIPTION
Resolved two warnings related to OMEGA_H_CHECK.
- `cmdline.parse()` is declared with `warn_unused_result` attribute. Checking the return value explicitly avoids the warning.
- Assertions are ignored in release mode. Use `OMEGA_H_CHECK` instead.