### PR TITLE
Add topological queries

### DIFF
--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -97,7 +97,7 @@ string(REGEX REPLACE
   "${SIM_VERSION}")
 
 set(MIN_VALID_SIM_VERSION 16.0.210606)
-set(MAX_VALID_SIM_VERSION 2023.1-231028)
+set(MAX_VALID_SIM_VERSION 2025.1.250507)
 if( ${SKIP_SIMMETRIX_VERSION_CHECK} )
   message(STATUS "Skipping Simmetrix SimModSuite version check."
     " This may result in undefined behavior")

--- a/src/Omega_h_model2d.cpp
+++ b/src/Omega_h_model2d.cpp
@@ -17,4 +17,18 @@ void Model2D::printInfo() {
   std::cout << "loop use, " << loopUseIds.size() << "\n";
 }
 
+//returns the edges in a loop use
+LOs Model2D::getEdgesinLoop(LO loopUse) const {
+  OMEGA_H_CHECK(loopUse < loopUseToEdgeUse.size());
+  LOs edgesUses = loopUseToEdgeUse[loopUse];
+  LOs edges(edgesUses.size());
+
+  Kokkos::parallel_for(
+      "getEdgesinLoop", edgesUses.size(),
+      KOKKOS_CLASS_LAMBDA(const LO index) {
+        edges[i] = edgeUseToVtx[edgesUses[i]];
+      });
+  return edges;
+}
+
 }  // namespace Omega_h

--- a/src/Omega_h_model2d.cpp
+++ b/src/Omega_h_model2d.cpp
@@ -17,18 +17,4 @@ void Model2D::printInfo() {
   std::cout << "loop use, " << loopUseIds.size() << "\n";
 }
 
-//returns the edges in a loop use
-LOs Model2D::getEdgesinLoop(LO loopUse) const {
-  OMEGA_H_CHECK(loopUse < loopUseToEdgeUse.size());
-  LOs edgesUses = loopUseToEdgeUse[loopUse];
-  LOs edges(edgesUses.size());
-
-  Kokkos::parallel_for(
-      "getEdgesinLoop", edgesUses.size(),
-      KOKKOS_CLASS_LAMBDA(const LO index) {
-        edges[i] = edgeUseToVtx[edgesUses[i]];
-      });
-  return edges;
-}
-
 }  // namespace Omega_h

--- a/src/Omega_h_model2d.hpp
+++ b/src/Omega_h_model2d.hpp
@@ -36,6 +36,7 @@ private:
   LOs loopUseOrientation;
 
   //geometry
+  //TODO: Implement a heuristic to determine these tolerances
   Real vtxTol, edgeTol;
   Reals vtxCoords;
 

--- a/src/Omega_h_model2d.hpp
+++ b/src/Omega_h_model2d.hpp
@@ -133,7 +133,25 @@ public:
    *  @return Read<LO> of loop use to face adjacencies.
    */
   OMEGA_H_INLINE LOs getLoopUseToFace() const { return loopUseToFace; }
+  /** @brief Get the edge use orientations.
+   *  
+   *  Returns a Read<LO> where each entry indicates the direction of the
+   *  edge use relative to its owning edge.
+   *  - 1: same direction.
+   *  - 0: opposite direction.
+   * 
+   *  @return Read<LO> of edge use orientations.
+   */
   OMEGA_H_INLINE LOs getEdgeUseOrientation() const { return edgeUseOrientation; }
+    /** @brief Get the loop use orientations.
+   *  
+   *  Returns a Read<LO> where each entry indicates the direction of the
+   *  loop use relative to its owning edge.
+   *  - 1: same direction.
+   *  - 0: opposite direction.
+   * 
+   *  @return Read<LO> of loop use orientations.
+   */
   OMEGA_H_INLINE LOs getLoopUseOrientation() const { return loopUseOrientation; }
   /** @brief Get the vertex tolerance.
    *  
@@ -147,7 +165,7 @@ public:
   OMEGA_H_INLINE Real getEdgeTol() const { return edgeTol; }
   /** @brief Get the vertex coordinates.
    *  
-   *  @return Read<Real> of vertex coordinates.
+   *  @return Read<Real> of vertex coordinates in the form {x_0,y_0,z_0, x_1,y_1,z_1...,x_n,y_n,z_n}.
    */
   OMEGA_H_INLINE Reals const& getVtxCoords() const { return vtxCoords; }
 };

--- a/src/Omega_h_model2d.hpp
+++ b/src/Omega_h_model2d.hpp
@@ -10,6 +10,60 @@ namespace Omega_h {
 class Mesh2D;
 
 class Model2D {
+
+private:
+  //ids
+  LOs vtxIds, edgeIds , faceIds;
+  LOs edgeUseIds, loopUseIds;
+  //equal order adjacencies
+  //each edge will have at most two uses, edges bounding a single face will only have one
+  Graph edgeToEdgeUse;
+  //downward adjacencies
+  Graph faceToLoopUse;
+  Graph loopUseToEdgeUse;
+  LOs edgeUseToVtx; //each edgeUse has exactly two adjacent vertices
+  //upward adjacencies
+  Graph vtxToEdgeUse;
+  LOs edgeUseToLoopUse; //each edgeUse has one adjacent loop use
+  LOs loopUseToFace; //each loopUse has one adjacent face use
+
+  //For each edgeUse, indicates the direction of the edge use 
+  //relative to its owning edge. 1: same dir, 0: opposite dir
+  LOs edgeUseOrientation;
+
+  //For each loopUse, indicates forward or backward traversal order
+  //of the edgeUses belonging to the loop.  1: forward, 0: backward
+  LOs loopUseOrientation;
+
+  //geometry
+  Real vtxTol, edgeTol;
+  Reals vtxCoords;
+
+  Model2D() = default;
+
+  //Model load helper functions
+  void setAdjInfo(Graph edgeToEdgeUse, LOs edgeUseToVtx, LOs loopUseToFace, LOs edgeUseToLoopUse);
+
+  void setVertexInfo(LOs ids, Reals coords) {
+    this->vtxIds = ids;
+    this->vtxCoords = coords;
+  }
+
+  void setEdgeInfo(LOs ids, LOs useIds, LOs useOrientation) {
+    this->edgeIds = ids;
+    this->edgeUseIds = useIds;
+    this->edgeUseOrientation = useOrientation;
+  }
+
+  void setFaceIds(LOs ids) {
+    this->faceIds = ids;
+  }
+
+  void setLoopUseIdsAndDir(LOs ids, LOs useOrientation) {
+    this->loopUseIds = ids;
+    this->loopUseOrientation = useOrientation;
+  }
+
 public:
   //constructors
 #ifdef OMEGA_H_USE_SIMMODSUITE
@@ -96,36 +150,6 @@ public:
    *  @return Read<Real> of vertex coordinates.
    */
   OMEGA_H_INLINE Reals const& getVtxCoords() const { return vtxCoords; }
-
-  private:
-  //ids
-  LOs vtxIds, edgeIds , faceIds;
-  LOs edgeUseIds, loopUseIds;
-  //equal order adjacencies
-  //each edge will have at most two uses, edges bounding a single face will only have one
-  Graph edgeToEdgeUse;
-  //downward adjacencies
-  Graph faceToLoopUse;
-  Graph loopUseToEdgeUse;
-  LOs edgeUseToVtx; //each edgeUse has exactly two adjacent vertices
-  //upward adjacencies
-  Graph vtxToEdgeUse;
-  LOs edgeUseToLoopUse; //each edgeUse has one adjacent loop use
-  LOs loopUseToFace; //each loopUse has one adjacent face use
-
-  //For each edgeUse, indicates the direction of the edge use 
-  //relative to its owning edge. 1: same dir, 0: opposite dir
-  LOs edgeUseOrientation;
-
-  //For each loopUse, indicates forward or backward traversal order
-  //of the edgeUses belonging to the loop.  1: forward, 0: backward
-  LOs loopUseOrientation;
-
-  //geometry
-  Real vtxTol, edgeTol;
-  Reals vtxCoords;
-
-  Model2D() = default;
 };
 
 }

--- a/src/Omega_h_model2d.hpp
+++ b/src/Omega_h_model2d.hpp
@@ -43,6 +43,9 @@ public:
   //geometry
   Real vtxTol, edgeTol;
   Reals vtxCoords;
+
+  LOs getEdgesinLoop(LO loopUse) const;
+
 private:
   Model2D() = default;
 };

--- a/src/Omega_h_model2d.hpp
+++ b/src/Omega_h_model2d.hpp
@@ -17,6 +17,87 @@ public:
 #endif
   static Model2D MeshModel2D_load(Mesh2D& mesh);
   void printInfo();
+  
+  //accessors
+  /** @brief Get the vertex ids of the model.
+   *  
+   *  @return Read<LO> of vertex ids.
+   */
+  OMEGA_H_INLINE LOs getVtxIds() const { return vtxIds; }
+  /** @brief Get the edge ids of the model.
+   *  
+   *  @return Read<LO> of edge ids.
+   */
+  OMEGA_H_INLINE LOs getEdgeIds() const { return edgeIds; }
+  /** @brief Get the face ids of the model.
+   *  
+   *  @return Read<LO> of face ids.
+   */
+  OMEGA_H_INLINE LOs getFaceIds() const { return faceIds; }
+    /** @brief Get the edge use ids of the model.
+   *  
+   *  @return Read<LO> of edge use ids.
+   */
+  OMEGA_H_INLINE LOs getEdgeUseIds() const { return edgeUseIds; }
+  /** @brief Get the loop use ids of the model.
+   *  
+   *  @return Read<LO> of loop use ids.
+   */
+  OMEGA_H_INLINE LOs getLoopUseIds() const { return loopUseIds; }
+  /** @brief Get the edge to edge use adjacency graph.
+   *  
+   *  @return Graph of edge to edge use adjacencies.
+   */
+  OMEGA_H_INLINE Graph getEdgeToEdgeUse() const { return edgeToEdgeUse; }
+  /** @brief Get the face to loop use adjacency graph.
+   *  
+   *  @return Graph of face to loop use adjacencies.
+   */
+  OMEGA_H_INLINE Graph getFaceToLoopUse() const { return faceToLoopUse; }
+  /** @brief Get the loop use to edge use adjacency graph.
+   *  
+   *  @return Graph of loop use to edge use adjacencies.
+   */
+  OMEGA_H_INLINE Graph getLoopUseToEdgeUse() const { return loopUseToEdgeUse; }
+  /** @brief Get the edge use to vertex adjacency array.
+   *  
+   *  @return Read<LO> of edge use to vertex adjacencies.
+   */
+  OMEGA_H_INLINE LOs getEdgeUseToVtx() const { return edgeUseToVtx; }
+  /** @brief Get the vertex to edge use adjacency graph.
+   *  
+   *  @return Graph of vertex to edge use adjacencies.
+   */
+  OMEGA_H_INLINE Graph getVtxToEdgeUse() const { return vtxToEdgeUse; }
+  /** @brief Get the edge use to loop use adjacency array.
+   *  
+   *  @return Read<LO> of edge use to loop use adjacencies.
+   */
+  OMEGA_H_INLINE LOs getEdgeUseToLoopUse() const { return edgeUseToLoopUse; }
+  /** @brief Get the loop use to face adjacency array.
+   *  
+   *  @return Read<LO> of loop use to face adjacencies.
+   */
+  OMEGA_H_INLINE LOs getLoopUseToFace() const { return loopUseToFace; }
+  OMEGA_H_INLINE LOs getEdgeUseOrientation() const { return edgeUseOrientation; }
+  OMEGA_H_INLINE LOs getLoopUseOrientation() const { return loopUseOrientation; }
+  /** @brief Get the vertex tolerance.
+   *  
+   *  @return Real value of vertex tolerance.
+   */
+  OMEGA_H_INLINE Real getVtxTol() const { return vtxTol; }
+  /** @brief Get the edge tolerance.
+   *  
+   *  @return Real value of edge tolerance.
+   */
+  OMEGA_H_INLINE Real getEdgeTol() const { return edgeTol; }
+  /** @brief Get the vertex coordinates.
+   *  
+   *  @return Read<Real> of vertex coordinates.
+   */
+  OMEGA_H_INLINE Reals const& getVtxCoords() const { return vtxCoords; }
+
+  private:
   //ids
   LOs vtxIds, edgeIds , faceIds;
   LOs edgeUseIds, loopUseIds;
@@ -44,9 +125,6 @@ public:
   Real vtxTol, edgeTol;
   Reals vtxCoords;
 
-  LOs getEdgesinLoop(LO loopUse) const;
-
-private:
   Model2D() = default;
 };
 

--- a/src/Omega_h_simModel2d.cpp
+++ b/src/Omega_h_simModel2d.cpp
@@ -370,47 +370,25 @@ struct Adjacencies {
   }
 };
 
-void setVertexInfo(Model2D& mdl, const VtxInfo& vtxInfo) {
-  mdl.vtxIds = vtxInfo.ids;
-  mdl.vtxCoords = vtxInfo.coords;
-}
+void Model2D::setAdjInfo(Graph edgeToEdgeUse, LOs edgeUseToVtx, LOs loopUseToFace, LOs edgeUseToLoopUse) {
 
-void setEdgeIds(Model2D& mdl, const EdgeInfo& edgeInfo) {
-  mdl.edgeIds = edgeInfo.ids;
-}
-
-void setFaceIds(Model2D& mdl, const FaceInfo& faceInfo) {
-  mdl.faceIds = faceInfo.ids;
-}
-
-void setLoopUseIdsAndDir(Model2D& mdl, const LoopUseInfo& loopUseInfo) {
-  mdl.loopUseIds = loopUseInfo.ids;
-  mdl.loopUseOrientation = loopUseInfo.dir;
-}
-
-void setEdgeUseIdsAndDir(Model2D& mdl, const EdgeUseInfo& edgeUseInfo) {
-  mdl.edgeUseIds = edgeUseInfo.ids;
-  mdl.edgeUseOrientation = edgeUseInfo.dir;
-}
-
-void setAdjInfo(Model2D& mdl, Adjacencies& adj) {
-  mdl.edgeToEdgeUse = Graph(LOs(adj.e2eu.offset), LOs(adj.e2eu.values));
-  mdl.edgeUseToVtx = LOs(adj.eu2v.values);
-  mdl.loopUseToFace = LOs(adj.lu2f.values);
-  mdl.edgeUseToLoopUse = LOs(adj.eu2lu.values);
+  this->edgeToEdgeUse = edgeToEdgeUse;
+  this->edgeUseToVtx = edgeUseToVtx;
+  this->loopUseToFace = loopUseToFace;
+  this->edgeUseToLoopUse = edgeUseToLoopUse;
 
   //The last two arguments to 'invert_adj(...)' are 'high' and 'low' entity
   //dimensions and are used to define names for the graph arrays. They have no
   //impact on the graph inversion.
-  mdl.vtxToEdgeUse = invert_adj(Adj(mdl.edgeUseToVtx),
+  this->vtxToEdgeUse = invert_adj(Adj(this->edgeUseToVtx),
                                 Adjacencies::eu2vDegree,
-                                mdl.vtxIds.size(), 1, 0);
-  mdl.loopUseToEdgeUse = invert_adj(Adj(mdl.edgeUseToLoopUse),
+                                this->vtxIds.size(), 1, 0);
+  this->loopUseToEdgeUse = invert_adj(Adj(this->edgeUseToLoopUse),
                                     Adjacencies::eu2luDegree,
-                                    mdl.loopUseIds.size(), 1, 1);
-  mdl.faceToLoopUse = invert_adj(Adj(mdl.loopUseToFace), 
+                                    this->loopUseIds.size(), 1, 1);
+  this->faceToLoopUse = invert_adj(Adj(this->loopUseToFace), 
                                  Adjacencies::lu2fDegree, 
-                                 mdl.faceIds.size(), 1, 2);
+                                 this->faceIds.size(), 1, 2);
 }
 
 void checkError(bool cond, std::string_view msg) {
@@ -452,12 +430,11 @@ Model2D Model2D::SimModel2D_load(std::string const& filename) {
 
   //setup model
   auto mdl = Model2D();
-  setVertexInfo(mdl, vtxInfo);
-  setEdgeIds(mdl, edgeInfo);
-  setFaceIds(mdl, faceInfo);
-  setLoopUseIdsAndDir(mdl, loopUseInfo);
-  setEdgeUseIdsAndDir(mdl, edgeUseInfo);
-  setAdjInfo(mdl, adj);
+  mdl.setVertexInfo(vtxInfo.ids, vtxInfo.coords);
+  mdl.setEdgeInfo(edgeInfo.ids, edgeUseInfo.ids, edgeUseInfo.dir);
+  mdl.setFaceIds(faceInfo.ids);
+  mdl.setLoopUseIdsAndDir(loopUseInfo.ids, loopUseInfo.dir);
+  mdl.setAdjInfo(Graph(LOs(adj.e2eu.offset), LOs(adj.e2eu.values)), LOs(adj.eu2v.values), LOs(adj.lu2f.values), LOs(adj.eu2lu.values));
 
   GM_release(g);
   return mdl;

--- a/src/simModel2dLoad_square.cpp
+++ b/src/simModel2dLoad_square.cpp
@@ -29,40 +29,40 @@ void printLOs(const Omega_h::LOs& arr, const int degree, std::string_view name) 
 void checkSquareModel(Omega_h::Model2D& model) {
   //the following were checked in SimModeler
   Omega_h::LOs expectedVtxIds = {19,15,11,10};
-  OMEGA_H_CHECK(model.vtxIds == expectedVtxIds);
+  OMEGA_H_CHECK(model.getVtxIds() == expectedVtxIds);
   Omega_h::LOs expectedEdgeIds = {6,12,16,20};
-  OMEGA_H_CHECK(model.edgeIds == expectedEdgeIds);
+  OMEGA_H_CHECK(model.getEdgeIds() == expectedEdgeIds);
   Omega_h::LOs expectedFaceIds = {2};
-  OMEGA_H_CHECK(model.faceIds == expectedFaceIds);
+  OMEGA_H_CHECK(model.getFaceIds() == expectedFaceIds);
 
   //In SimModeler, use ids and their adjacencies are **not** accessible/visible
   Omega_h::LOs expectedEdgeUseIds = {8,6,4,2,1,3,5,7};
-  OMEGA_H_CHECK(model.edgeUseIds == expectedEdgeUseIds);
+  OMEGA_H_CHECK(model.getEdgeUseIds() == expectedEdgeUseIds);
   Omega_h::LOs expectedLoopUseIds = {2,1};
-  OMEGA_H_CHECK(model.loopUseIds == expectedLoopUseIds);
+  OMEGA_H_CHECK(model.getLoopUseIds() == expectedLoopUseIds);
 
   //check adjacencies
   Omega_h::Graph expected_e2eu = Omega_h::Graph({0,2,4,6,8},{3,4,2,5,1,6,0,7});
-  OMEGA_H_CHECK(model.edgeToEdgeUse == expected_e2eu);
+  OMEGA_H_CHECK(model.getEdgeToEdgeUse() == expected_e2eu);
 
   Omega_h::LOs expected_eu2lu = {0,0,0,0,1,1,1,1};
-  OMEGA_H_CHECK(model.edgeUseToLoopUse == expected_eu2lu);
+  OMEGA_H_CHECK(model.getEdgeUseToLoopUse() == expected_eu2lu);
   Omega_h::Graph expected_lu2eu = Omega_h::Graph({0,4,8},{0,1,2,3,4,5,6,7});
-  OMEGA_H_CHECK(model.loopUseToEdgeUse == expected_lu2eu);
+  OMEGA_H_CHECK(model.getLoopUseToEdgeUse() == expected_lu2eu);
 
   Omega_h::LOs expected_eu2v = {0,3,1,0,2,1,3,2,3,2,2,1,1,0,0,3};
-  OMEGA_H_CHECK(model.edgeUseToVtx == expected_eu2v);
+  OMEGA_H_CHECK(model.getEdgeUseToVtx() == expected_eu2v);
   Omega_h::Graph expected_v2eu = Omega_h::Graph({0,4,8,12,16},
                                                 {0,1,6,7,
                                                  1,2,5,6,
                                                  2,3,4,5,
                                                  0,3,4,7});
-  OMEGA_H_CHECK(model.vtxToEdgeUse == expected_v2eu);
+  OMEGA_H_CHECK(model.getVtxToEdgeUse() == expected_v2eu);
 
   Omega_h::LOs expected_lu2f = {0,0};
-  OMEGA_H_CHECK(model.loopUseToFace == expected_lu2f);
+  OMEGA_H_CHECK(model.getLoopUseToFace() == expected_lu2f);
   Omega_h::Graph expected_f2lu = Omega_h::Graph({0,2},{0,1});
-  OMEGA_H_CHECK(model.faceToLoopUse == expected_f2lu);
+  OMEGA_H_CHECK(model.getFaceToLoopUse() == expected_f2lu);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Adds topological queries to the Model2D Class by:
- Making the Model2D Fields private, and providing inline "getter" functions
- Reworking the Model2D loading routine. It now utilizes private helper functions to populate the Model2D Fields
- Adding documentation with oxygen.

This PR also bumps the maximum version of Simmetrix to 2025.1.250507.