### PR TITLE
Minor Fix: Issue causing bad values for large arrays has been fixed

### DIFF
--- a/src/Omega_h_adios2.cpp
+++ b/src/Omega_h_adios2.cpp
@@ -95,7 +95,7 @@ static void write_array(adios2::IO &io, adios2::Engine &writer, Mesh* mesh,
   adios2::Variable<T> bpData = 
 	  io.DefineVariable<T>(
           name, {comm_size * Nx, n_comp}, {rank * Nx,0}, {Nx, n_comp}, adios2::ConstantDims);
-  writer.Put(bpData, myData.data());
+  writer.Put(bpData, myData.data(), adios2::Mode::Sync);
 }
 
 template <typename T>


### PR DESCRIPTION
Some of the variables in adios2 with large size had invalid data on writing from Omega_h mesh data to adios2 variables. This PR fixes the issue.