### PR TITLE
Add force_resize boolean to write_vtu

### DIFF
--- a/src/Omega_h_file.hpp
+++ b/src/Omega_h_file.hpp
@@ -153,16 +153,16 @@ static constexpr bool dont_compress = false;
 TagSet get_all_vtk_tags(Mesh* mesh, Int cell_dim);
 TagSet get_all_vtk_tags_mix(Mesh* mesh, Int cell_dim);
 void write_vtu(std::ostream& stream, Mesh* mesh, Int cell_dim,
-    TagSet const& tags, bool compress = OMEGA_H_DEFAULT_COMPRESS);
+    TagSet const& tags, bool compress = OMEGA_H_DEFAULT_COMPRESS, bool force_resize = true);
 void write_vtu(filesystem::path const& filename, Mesh* mesh, Int cell_dim,
-    TagSet const& tags, bool compress = OMEGA_H_DEFAULT_COMPRESS);
+    TagSet const& tags, bool compress = OMEGA_H_DEFAULT_COMPRESS, bool force_resize = true);
 void write_vtu(std::string const& filename, Mesh* mesh, Int cell_dim,
-    bool compress = OMEGA_H_DEFAULT_COMPRESS);
+    bool compress = OMEGA_H_DEFAULT_COMPRESS, bool force_resize = true);
 void write_vtu(std::string const& filename, Mesh* mesh,
-    bool compress = OMEGA_H_DEFAULT_COMPRESS);
+    bool compress = OMEGA_H_DEFAULT_COMPRESS, bool force_resize = true);
 
 void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_type,
-    bool compress = OMEGA_H_DEFAULT_COMPRESS);
+    bool compress = OMEGA_H_DEFAULT_COMPRESS, bool force_resize = true);
 
 void write_parallel(filesystem::path const& path, Mesh* mesh, Int cell_dim,
     TagSet const& tags, bool compress = OMEGA_H_DEFAULT_COMPRESS);

--- a/src/Omega_h_vtk.cpp
+++ b/src/Omega_h_vtk.cpp
@@ -263,21 +263,21 @@ static Read<T> read_array(
 
 namespace detail {
 template <typename T>
-static void write_tag_impl(
-    TagBase const* tag, Int space_dim, std::ostream& stream, bool compress) {
+static void write_tag_impl(TagBase const* tag, Int space_dim, std::ostream& stream,
+    bool compress, bool force_resize) {
   const auto ncomps = tag->ncomps();
   const auto name = tag->name();
   auto array = as<T>(tag)->array();
   write_array(stream, name, ncomps, array, compress);
 }
 template <>
-void write_tag_impl<Real>(
-    TagBase const* tag, Int space_dim, std::ostream& stream, bool compress) {
+void write_tag_impl<Real>(TagBase const* tag, Int space_dim, std::ostream& stream,
+    bool compress, bool force_resize) {
   const auto ncomps = tag->ncomps();
   const auto name = tag->name();
   auto array = as<Real>(tag)->array();
   // don't use array from "tag" b/c change_tagToMesh creates new tag
-  if (1 < space_dim && space_dim < 3) {
+  if (1 < space_dim && space_dim < 3 && force_resize) {
     if (ncomps == space_dim) {
       // VTK / ParaView expect vector fields to have 3 components
       // regardless of whether this is a 2D mesh or not.
@@ -300,13 +300,13 @@ void write_tag_impl<Real>(
 }  // namespace detail
 
 void write_tag(std::ostream& stream, TagBase const* tag, Int space_dim,
-    Int ent_dim, bool compress) {
+    Int ent_dim, bool compress, bool force_resize) {
   OMEGA_H_TIME_FUNCTION;
   const auto name = tag->name();
   const auto class_ids = tag->class_ids();
   // TODO: write class id info for rc tag to file
   apply_to_omega_h_types(tag->type(), [&](auto t) {
-    detail::write_tag_impl<decltype(t)>(tag, space_dim, stream, compress);
+    detail::write_tag_impl<decltype(t)>(tag, space_dim, stream, compress, force_resize);
 });
 }
 
@@ -767,7 +767,7 @@ void write_vtkfile_vtu_start_tag(std::ostream& stream, bool compress) {
 }
 
 void write_vtu(std::ostream& stream, Mesh* mesh, Int cell_dim,
-    TagSet const& tags, bool compress) {
+    TagSet const& tags, bool compress, bool force_resize) {
   OMEGA_H_TIME_FUNCTION;
   default_dim(mesh->dim(), &cell_dim);
   verify_vtk_tagset(mesh, cell_dim, tags);
@@ -786,14 +786,14 @@ void write_vtu(std::ostream& stream, Mesh* mesh, Int cell_dim,
   /* globals go first so read_vtu() knows where to find them */
   if (mesh->has_tag(VERT, "global") && tags[VERT].count("global")) {
     write_tag(stream, mesh->get_tag<GO>(VERT, "global"), mesh->dim(), VERT,
-        compress);
+        compress, force_resize);
   }
   write_locals_and_owners(stream, mesh, VERT, tags, compress);
   for (Int i = 0; i < mesh->ntags(VERT); ++i) {
     auto tag = mesh->get_tag(VERT, i);
     if (tag->name() != "coordinates" && tag->name() != "global" &&
         tags[VERT].count(tag->name())) {
-      write_tag(stream, tag, mesh->dim(), VERT, compress);
+      write_tag(stream, tag, mesh->dim(), VERT, compress, force_resize);
     }
   }
   stream << "</PointData>\n";
@@ -802,7 +802,7 @@ void write_vtu(std::ostream& stream, Mesh* mesh, Int cell_dim,
   if (mesh->has_tag(cell_dim, "global") &&
       tags[size_t(cell_dim)].count("global")) {
     write_tag(stream, mesh->get_tag<GO>(cell_dim, "global"), mesh->dim(),
-        cell_dim, compress);
+        cell_dim, compress, force_resize);
   }
   write_locals_and_owners(stream, mesh, cell_dim, tags, compress);
   if (tags[size_t(cell_dim)].count("vtkGhostType")) {
@@ -811,7 +811,7 @@ void write_vtu(std::ostream& stream, Mesh* mesh, Int cell_dim,
   for (Int i = 0; i < mesh->ntags(cell_dim); ++i) {
     auto tag = mesh->get_tag(cell_dim, i);
     if (tag->name() != "global" && tags[size_t(cell_dim)].count(tag->name())) {
-      write_tag(stream, tag, mesh->dim(), cell_dim, compress);
+      write_tag(stream, tag, mesh->dim(), cell_dim, compress, force_resize);
     }
   }
   stream << "</CellData>\n";
@@ -821,7 +821,7 @@ void write_vtu(std::ostream& stream, Mesh* mesh, Int cell_dim,
 }
 
 void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_type,
-    bool compress) {
+    bool compress, bool force_resize) {
   auto tags = get_all_vtk_tags_mix(mesh, mesh->dim());
   OMEGA_H_TIME_FUNCTION;
   std::ofstream stream(filename.c_str());
@@ -843,13 +843,13 @@ void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_
   stream << "<PointData>\n";
   if (mesh->has_tag(Topo_type::vertex, "global") && tags[VERT].count("global")) {
     write_tag(stream, mesh->get_tag<GO>(Topo_type::vertex, "global"), mesh->dim(), 0,
-        compress);
+        compress, force_resize);
   }
   for (Int i = 0; i < mesh->ntags(Topo_type::vertex); ++i) {
     auto tag = mesh->get_tag(Topo_type::vertex, i);
     if (tag->name() != "coordinates" && tag->name() != "global" &&
         tags[VERT].count(tag->name())) {
-      write_tag(stream, tag, mesh->dim(), 0, compress);
+      write_tag(stream, tag, mesh->dim(), 0, compress, force_resize);
     }
   }
   stream << "</PointData>\n";
@@ -860,7 +860,7 @@ void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_
       auto tag = mesh->get_tag(Topo_type::tetrahedron, i);
       if (tag->name() != "global" &&
           tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), cell_dim, compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, compress, force_resize);
       }
     }
 
@@ -868,7 +868,7 @@ void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_
       auto tag = mesh->get_tag(Topo_type::hexahedron, i);
       if (tag->name() != "global" &&
           tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), cell_dim, compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, compress, force_resize);
       }
     }
 
@@ -876,7 +876,7 @@ void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_
       auto tag = mesh->get_tag(Topo_type::wedge, i);
       if (tag->name() != "global" &&
           tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), cell_dim, compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, compress, force_resize);
       }
     }
 
@@ -884,7 +884,7 @@ void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_
       auto tag = mesh->get_tag(Topo_type::pyramid, i);
       if (tag->name() != "global" &&
           tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), cell_dim, compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, compress, force_resize);
       }
     }
   } else if (cell_dim == 2) {
@@ -892,7 +892,7 @@ void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_
       auto tag = mesh->get_tag(Topo_type::triangle, i);
       if (tag->name() != "global" &&
           tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), cell_dim, compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, compress, force_resize);
       }
     }
 
@@ -900,7 +900,7 @@ void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_
       auto tag = mesh->get_tag(Topo_type::quadrilateral, i);
       if (tag->name() != "global" &&
           tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), cell_dim, compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, compress, force_resize);
       }
     }
   } else { //cell_dim == 1 or 0
@@ -909,7 +909,7 @@ void write_vtu(filesystem::path const& filename, MixedMesh* mesh, Topo_type max_
       auto tag = mesh->get_tag(cellTopoType, i);
       if (tag->name() != "global" &&
           tags[size_t(cell_dim)].count(tag->name())) {
-        write_tag(stream, tag, mesh->dim(), cell_dim, compress);
+        write_tag(stream, tag, mesh->dim(), cell_dim, compress, force_resize);
       }
     }
   }
@@ -989,22 +989,23 @@ void read_vtu_ents(std::istream& stream, Mesh* mesh) {
 }
 
 void write_vtu(filesystem::path const& filename, Mesh* mesh, Int cell_dim,
-    TagSet const& tags, bool compress) {
+    TagSet const& tags, bool compress, bool force_resize) {
   std::ofstream file(filename.c_str());
   OMEGA_H_CHECK(file.is_open());
   ask_for_mesh_tags(mesh, tags);
-  write_vtu(file, mesh, cell_dim, tags, compress);
+  write_vtu(file, mesh, cell_dim, tags, compress, force_resize);
+}
+
+void write_vtu(std::string const& filename, Mesh* mesh, Int cell_dim,
+    bool compress, bool force_resize) {
+  default_dim(mesh->dim(), &cell_dim);
+  write_vtu(filename, mesh, cell_dim, get_all_vtk_tags(mesh, cell_dim),
+      compress, force_resize);
 }
 
 void write_vtu(
-    std::string const& filename, Mesh* mesh, Int cell_dim, bool compress) {
-  default_dim(mesh->dim(), &cell_dim);
-  write_vtu(
-      filename, mesh, cell_dim, get_all_vtk_tags(mesh, cell_dim), compress);
-}
-
-void write_vtu(std::string const& filename, Mesh* mesh, bool compress) {
-  write_vtu(filename, mesh, mesh->dim(), compress);
+  std::string const& filename, Mesh* mesh, bool compress, bool force_resize) {
+  write_vtu(filename, mesh, mesh->dim(), compress, force_resize);
 }
 
 void write_pvtu(std::ostream& stream, Mesh* mesh, Int cell_dim,


### PR DESCRIPTION
Solved issue. #114 . This issue occurs when the system automatically resizes certain VTK or symmetric tensor inputs. To ensure compatibility with current implementations, introduce a boolean flag that enables users to disable the resize behavior when needed.