### PR TITLE
simmodsuite: move start and stop calls to library

### DIFF
--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -97,7 +97,7 @@ string(REGEX REPLACE
   "${SIM_VERSION}")
 
 set(MIN_VALID_SIM_VERSION 16.0.210606)
-set(MAX_VALID_SIM_VERSION 2023.1-231028)
+set(MAX_VALID_SIM_VERSION 2025.0.250108)
 if( ${SKIP_SIMMETRIX_VERSION_CHECK} )
   message(STATUS "Skipping Simmetrix SimModSuite version check."
     " This may result in undefined behavior")

--- a/src/Omega_h_library.cpp
+++ b/src/Omega_h_library.cpp
@@ -12,6 +12,13 @@
 #include <sstream>
 #include <string>
 
+#if defined(OMEGA_H_USE_SIMMODSUITE)
+#include "MeshSim.h"
+#if defined(OMEGA_H_USE_SIMDISCRETE)
+#include "SimDiscrete.h"
+#endif
+#endif
+
 #ifdef OMEGA_H_DBG
 Omega_h::Comm *DBG_COMM = 0;
 bool dbg_print_global = false;
@@ -176,6 +183,14 @@ void Library::initialize(char const* head_desc, int* argc, char*** argv
   cudaFree(nullptr);
 #endif
   if (cmdline.parsed("--osh-pool")) enable_pooling();
+#if defined(OMEGA_H_USE_SIMMODSUITE)
+  MS_init();
+  SimModel_start();
+  Sim_readLicenseFile(NULL);
+  #if defined(OMEGA_H_USE_SIMDISCRETE)
+  SimDiscrete_start(0);
+  #endif
+#endif
 }
 
 Library::Library(Library const& other)
@@ -221,6 +236,13 @@ Library::~Library() {
     OMEGA_H_CHECK(MPI_SUCCESS == MPI_Finalize());
     we_called_mpi_init = false;
   }
+#endif
+#if defined(OMEGA_H_USE_SIMMODSUITE)
+  MS_exit();
+  #if defined(OMEGA_H_USE_SIMDISCRETE)
+  SimDiscrete_stop(0);
+  #endif
+  SimModel_stop();
 #endif
   delete[] Omega_h::max_memory_stacktrace;
 }

--- a/src/Omega_h_meshsim.cpp
+++ b/src/Omega_h_meshsim.cpp
@@ -711,11 +711,6 @@ void read_internal(pMesh m, Mesh* mesh, pMeshNex numbering, SimMeshInfo info, pM
 MixedMesh readMixedImpl(filesystem::path const& mesh_fname,
     filesystem::path const& mdl_fname,
     CommPtr comm) {
-  MS_init();
-  Sim_readLicenseFile(NULL);
-#ifdef OMEGA_H_USE_SIMDISCRETE
-  SimDiscrete_start(0);
-#endif
   pNativeModel nm = NULL;
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
@@ -726,10 +721,6 @@ MixedMesh readMixedImpl(filesystem::path const& mesh_fname,
   meshsim::readMixed_internal(m, &mesh, simMeshInfo);
   M_release(m);
   GM_release(g);
-#ifdef OMEGA_H_USE_SIMDISCRETE
-  SimDiscrete_stop(0);
-#endif
-  MS_exit();
   return mesh;
 }
 
@@ -747,11 +738,6 @@ Mesh read(pMesh* m, filesystem::path const& numbering_fname, CommPtr comm, pMesh
 
 Mesh readImpl(filesystem::path const& mesh_fname, filesystem::path const& mdl_fname,
     filesystem::path const& numbering_fname, CommPtr comm) {
-  MS_init();
-  Sim_readLicenseFile(NULL);
-#ifdef OMEGA_H_USE_SIMDISCRETE
-  SimDiscrete_start(0);
-#endif
   pNativeModel nm = NULL;
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
@@ -759,19 +745,10 @@ Mesh readImpl(filesystem::path const& mesh_fname, filesystem::path const& mdl_fn
   auto mesh = read(&m, numbering_fname, comm);
   M_release(m);
   GM_release(g);
-#ifdef OMEGA_H_USE_SIMDISCRETE
-  SimDiscrete_stop(0);
-#endif
-  MS_exit();
   return mesh;
 }
 
 bool isMixed(filesystem::path const& mesh_fname, filesystem::path const& mdl_fname) {
-  MS_init();
-  Sim_readLicenseFile(NULL);
-#ifdef OMEGA_H_USE_SIMDISCRETE
-  SimDiscrete_start(0);
-#endif
   pNativeModel nm = NULL;
   pProgress p = NULL;
   pGModel g = GM_load(mdl_fname.c_str(), nm, p);
@@ -779,10 +756,6 @@ bool isMixed(filesystem::path const& mesh_fname, filesystem::path const& mdl_fna
   auto simMeshInfo = getSimMeshInfo(m);
   M_release(m);
   GM_release(g);
-#ifdef OMEGA_H_USE_SIMDISCRETE
-  SimDiscrete_stop(0);
-#endif
-  MS_exit();
   bool isMixed = (!simMeshInfo.is_simplex && !simMeshInfo.is_hypercube);
   return isMixed;
 }

--- a/src/mixed_writeMesh.cpp
+++ b/src/mixed_writeMesh.cpp
@@ -45,10 +45,7 @@ void finalize_write(int numVerts, const double *coords, int numElems,
                     pEntity *eReturn, const char *mesh_path,
                     const char *model_path) {
   Sim_logOn("importData1.log");
-  MS_init();
-  Sim_readLicenseFile(0);
   pMesh meshtest;
-  SimDiscrete_start(0);
   Sim_setMessageHandler(messageHandler);
   pProgress progress = Progress_new();
   Progress_setDefaultCallback(progress);
@@ -81,9 +78,6 @@ void finalize_write(int numVerts, const double *coords, int numElems,
   M_release(meshtest);
   GM_release(modeltest);
   Progress_delete(progress);
-  SimDiscrete_stop(0);
-  Sim_unregisterAllKeys();
-  MS_exit();
   Sim_logOff();
 }
 


### PR DESCRIPTION
This approach reduces the chance of calling the initialization sequence for simmodsuite components/libraries in the wrong order and having to repeat that code in multiple locations.