### PR TITLE
Remove deprecated code usage for Kokkos > 4.7.00

### DIFF
--- a/src/Omega_h_array.cpp
+++ b/src/Omega_h_array.cpp
@@ -172,10 +172,10 @@ T Read<T>::last() const {
 
 #ifdef OMEGA_H_USE_KOKKOS
 template <class T, class... P>
-inline typename Kokkos::View<T, P...>::HostMirror create_uninit_mirror(
+inline typename Kokkos::View<T, P...>::host_mirror_type create_uninit_mirror(
     const Kokkos::View<T, P...>& src) {
   typedef Kokkos::View<T, P...> src_type;
-  typedef typename src_type::HostMirror dst_type;
+  typedef typename src_type::host_mirror_type dst_type;
   static_assert(src_type::rank == 1, "Hardcoded for 1D Views!");
   return dst_type(Kokkos::ViewAllocateWithoutInitializing(
                       std::string("host_") + src.label()),
@@ -183,25 +183,25 @@ inline typename Kokkos::View<T, P...>::HostMirror create_uninit_mirror(
 }
 
 template <class T, class... P>
-inline typename Kokkos::View<T, P...>::HostMirror create_uninit_mirror_view(
+inline typename Kokkos::View<T, P...>::host_mirror_type create_uninit_mirror_view(
     const Kokkos::View<T, P...>& src,
     typename std::enable_if<(
         std::is_same<typename Kokkos::View<T, P...>::memory_space,
-            typename Kokkos::View<T, P...>::HostMirror::memory_space>::value &&
+            typename Kokkos::View<T, P...>::host_mirror_type::memory_space>::value &&
         std::is_same<typename Kokkos::View<T, P...>::data_type,
-            typename Kokkos::View<T, P...>::HostMirror::data_type>::value)>::
+            typename Kokkos::View<T, P...>::host_mirror_type::data_type>::value)>::
         type* = nullptr) {
   return src;
 }
 
 template <class T, class... P>
-inline typename Kokkos::View<T, P...>::HostMirror create_uninit_mirror_view(
+inline typename Kokkos::View<T, P...>::host_mirror_type create_uninit_mirror_view(
     const Kokkos::View<T, P...>& src,
     typename std::enable_if<!(
         std::is_same<typename Kokkos::View<T, P...>::memory_space,
-            typename Kokkos::View<T, P...>::HostMirror::memory_space>::value &&
+            typename Kokkos::View<T, P...>::host_mirror_type::memory_space>::value &&
         std::is_same<typename Kokkos::View<T, P...>::data_type,
-            typename Kokkos::View<T, P...>::HostMirror::data_type>::value)>::
+            typename Kokkos::View<T, P...>::host_mirror_type::data_type>::value)>::
         type* = nullptr) {
   return create_uninit_mirror(src);
 }

--- a/src/Omega_h_array.hpp
+++ b/src/Omega_h_array.hpp
@@ -154,7 +154,7 @@ template <typename T>
 class HostWrite {
   Write<T> write_;
 #ifdef OMEGA_H_USE_KOKKOS
-  typename View<T*>::HostMirror mirror_;
+  typename View<T*>::host_mirror_type mirror_;
 #elif defined(OMEGA_H_USE_CUDA)
   std::shared_ptr<T[]> mirror_;
 #endif

--- a/src/Omega_h_rcFields.cpp
+++ b/src/Omega_h_rcFields.cpp
@@ -276,7 +276,7 @@ Read<T> Mesh::get_rc_mesh_array_from_rc_array(
   auto f = OMEGA_H_LAMBDA(LO i) {
     auto id = rc_ids[i];
     for (LO n = 0; n < ncomps; ++n) {
-      if ((mesh_field[id * ncomps + n] - OMEGA_H_INTERIOR_VAL) < EPSILON) {
+      if ((mesh_field[id * ncomps + n] - static_cast<T>(OMEGA_H_INTERIOR_VAL)) < EPSILON) {
         mesh_field[id * ncomps + n] = rc_field[i * ncomps + n];
       }
     }


### PR DESCRIPTION
- Replace deprecated `View::HostMirror` with `View::host_mirror_type`.
- Added explicit type conversions to resolve compilation errors with stricter compilers required by newer Kokkos versions
