### PR TITLE
Add git installation to CUDA workflow

### DIFF
--- a/.github/workflows/cmake-cuda.yml
+++ b/.github/workflows/cmake-cuda.yml
@@ -20,6 +20,9 @@ jobs:
             cxx_standard: 20     
 
     steps:
+    - name: Install CMake and ZLib
+      run: apt update && apt install -y cmake zlib1g-dev git
+    
     - uses: actions/checkout@v4
       with:
         path: omega_h
@@ -28,9 +31,6 @@ jobs:
       with:
         repository: kokkos/kokkos
         path: kokkos
-
-    - name: Install CMake and ZLib
-      run: apt update && apt install -y cmake zlib1g-dev
 
     - name: Configure Kokkos
       shell: bash


### PR DESCRIPTION
Installs git in the CUDA workflow to fix Kokkos configuration failures caused by missing files.