### PR TITLE
Update Frontier Globus test to use default environment modules and Kokkos develop branch

### DIFF
--- a/.github/workflows/frontier/install.sh
+++ b/.github/workflows/frontier/install.sh
@@ -4,6 +4,7 @@ branch=$1
 
 cd /lustre/orion/phy122/scratch/castia5/globus-compute/omega_h-test
 
+module load PrgEnv-amd
 module load rocm
 module load craype-accel-amd-gfx90a
 module load cray-mpich
@@ -13,9 +14,10 @@ export MPICH_GPU_SUPPORT_ENABLED=1
 # # Kokkos
 # rm kokkos -rf
 # rm build-kokkos -rf
-# git clone -b 4.1.00 git@github.com:Kokkos/kokkos.git
+# git clone git@github.com:Kokkos/kokkos.git
 # cmake -S kokkos -B build-kokkos \
 #  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#  -DCMAKE_CXX_STANDARD=20 \
 #  -DCMAKE_CXX_COMPILER=CC \
 #  -DCMAKE_CXX_EXTENSIONS=OFF \
 #  -DKokkos_ENABLE_TESTS=OFF \

--- a/.github/workflows/frontier/install.sh
+++ b/.github/workflows/frontier/install.sh
@@ -11,24 +11,24 @@ module load cray-mpich
 export CRAYPE_LINK_TYPE=dynamic
 export MPICH_GPU_SUPPORT_ENABLED=1
 
-# # Kokkos
-# rm kokkos -rf
-# rm build-kokkos -rf
-# git clone git@github.com:Kokkos/kokkos.git
-# cmake -S kokkos -B build-kokkos \
-#  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-#  -DCMAKE_CXX_STANDARD=20 \
-#  -DCMAKE_CXX_COMPILER=CC \
-#  -DCMAKE_CXX_EXTENSIONS=OFF \
-#  -DKokkos_ENABLE_TESTS=OFF \
-#  -DKokkos_ENABLE_EXAMPLES=OFF \
-#  -DKokkos_ENABLE_HIP=ON \
-#  -DKokkos_ARCH_VEGA90A=ON \
-#  -DKokkos_ENABLE_SERIAL=ON \
-#  -DKokkos_ENABLE_OPENMP=OFF \
-#  -DKokkos_ENABLE_DEBUG=OFF \
-#  -DCMAKE_INSTALL_PREFIX=build-kokkos/install
-# cmake --build build-kokkos -j8 --target install
+# Kokkos
+rm kokkos -rf
+rm build-kokkos -rf
+git clone git@github.com:Kokkos/kokkos.git
+cmake -S kokkos -B build-kokkos \
+ -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+ -DCMAKE_CXX_STANDARD=20 \
+ -DCMAKE_CXX_COMPILER=CC \
+ -DCMAKE_CXX_EXTENSIONS=OFF \
+ -DKokkos_ENABLE_TESTS=OFF \
+ -DKokkos_ENABLE_EXAMPLES=OFF \
+ -DKokkos_ENABLE_HIP=ON \
+ -DKokkos_ARCH_VEGA90A=ON \
+ -DKokkos_ENABLE_SERIAL=ON \
+ -DKokkos_ENABLE_OPENMP=OFF \
+ -DKokkos_ENABLE_DEBUG=OFF \
+ -DCMAKE_INSTALL_PREFIX=build-kokkos/install
+cmake --build build-kokkos -j8 --target install
 
 # Omega_h
 rm omega_h -rf

--- a/.github/workflows/frontier/run.sh
+++ b/.github/workflows/frontier/run.sh
@@ -4,6 +4,7 @@ name=omega_h
 
 cd /lustre/orion/phy122/scratch/castia5/globus-compute/$name-test
 
+module load PrgEnv-amd
 module load rocm
 module load craype-accel-amd-gfx90a
 module load cray-mpich


### PR DESCRIPTION
The recommended usage of PrgEnv-amd module layout can be found [here](https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#olcfdev-1799-new-rocm-module-layout-for-prgenv-amd). The current latest version is ROCm/6.2.4. Also, C++20 standard is required.