### PR TITLE
Add warnings-as-errors build to self-hosted CI

### DIFF
--- a/.github/workflows/pr_comment_trigger_self_hosted.yml
+++ b/.github/workflows/pr_comment_trigger_self_hosted.yml
@@ -281,11 +281,10 @@ jobs:
           cmake -S omegah_${{ github.event.issue.number }} -B $bdir \
             -DCMAKE_INSTALL_PREFIX=$bdir/install \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_CXX_FLAGS='-Werror' \
+            -DCMAKE_CXX_FLAGS='-Wall -Werror' \
             -DBUILD_TESTING=on  \
             -DOmega_h_USE_MPI=on  \
             -DOmega_h_USE_SimModSuite=off \
-            -DSIM_MPI=mpich4.2.3 \
             -DOmega_h_USE_Kokkos=on \
             -DOmega_h_CUDA_ARCH="80" \
             -DCMAKE_CUDA_ARCHITECTURES="80" \


### PR DESCRIPTION
Add a new build configuration with warnings treated as errors in self-hosted tests. Addressed issue #185 