### PR TITLE
Test to Demonstrate Mesh Library Lifetime

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -540,10 +540,8 @@ if(BUILD_TESTING)
     test_func(run_mpi_unit_io 2 ./unit_io)
   endif()
 
-  if(Omega_h_USE_MPI)
-    osh_add_exe(test_associated_library_lifetime)
-    will_fail_test_func(run_test_associated_library_lifetime 1 ./test_associated_library_lifetime)
-  endif ()
+  osh_add_exe(test_associated_library_lifetime)
+  will_fail_test_func(run_test_associated_library_lifetime 1 ./test_associated_library_lifetime)
 
   osh_add_exe(corner_test)
   test_func(run_corner_test 1 ./corner_test)

--- a/src/test_associated_library_lifetime.cpp
+++ b/src/test_associated_library_lifetime.cpp
@@ -1,5 +1,3 @@
-#include <mpi.h>
-
 #include <iostream>
 
 #include "Omega_h_build.hpp"
@@ -8,44 +6,53 @@
 #include "Omega_h_mesh.hpp"
 
 Omega_h::Mesh make_mesh_wrong_with_buildbox(int argc, char** argv) {
-  Omega_h::Library lib(&argc, &argv, MPI_COMM_SELF);
+  Omega_h::Library lib(&argc, &argv);
 
   // Mesh is built with a pointer to a library that will go out of scope
   Omega_h::Mesh mesh =
       Omega_h::build_box(lib.world(), OMEGA_H_SIMPLEX, 1, 1, 1, 1, 1, 1);
-  printf("Library world size inside function: %d.\n", lib.world()->size());
+  printf("Library.silent_ %d.\n", lib.silent_);
+  printf("Library.argv_.size() member %zu.\n", lib.argv_.size());
+  printf("Library.self_send_threshold_ %d.\n", lib.self_send_threshold_);
 
   return mesh;
 }
 
 Omega_h::Mesh make_mesh_wrong_with_constructor(int argc, char** argv) {
-  Omega_h::Library lib(&argc, &argv, MPI_COMM_SELF);
+  Omega_h::Library lib(&argc, &argv);
 
   // Library pointer is being copied
   Omega_h::Mesh mesh(&lib);
-  printf("Library world size inside function: %d.\n", lib.world()->size());
+  printf("Library.silent_ %d.\n", lib.silent_);
+  printf("Library.argv_.size() member %zu.\n", lib.argv_.size());
 
   // out of scope library after return
   return mesh;
 }
 
 int main(int argc, char** argv) {
-  MPI_Init(&argc, &argv);
-
   Omega_h::Mesh m_box = make_mesh_wrong_with_buildbox(argc, argv);
   Omega_h::Mesh m_ctor = make_mesh_wrong_with_constructor(argc, argv);
 
   // Problematic access to the library after it has been destroyed
-  auto lib_box = m_box.library();
-  auto lib_ctor = m_ctor.library();
+  const Omega_h::Library* lib_box = m_box.library();
+  const Omega_h::Library* lib_ctor = m_ctor.library();
 
   // Will fail here
-  int world_size_box = lib_box->world()->size();
-  int world_size_ctor = lib_ctor->world()->size();
+  const bool silent_mbox = lib_box->silent_;
+  const bool silent_mctor = lib_ctor->silent_;
+  const size_t size_mbox = lib_box->argv_.size();
+  const size_t size_mcotr = lib_ctor->argv_.size();
+  const int self_send_threshold = lib_box->self_send_threshold_;
+  const int self_send_threshold_ctor = lib_ctor->self_send_threshold_;
 
-  // code to makes sure the values are used to skip compiler optimizations
-  printf("World size from box mesh: %d.\n", world_size_box);
-  printf("World size from ctor mesh: %d.\n", world_size_ctor);
+  printf(
+      "Build_box Mesh: silent_ %d, argv_.size() %zu, self_send_threshold %d.\n",
+      silent_mbox, size_mbox, self_send_threshold);
+  printf(
+      "Constructed Mesh: silent_ %d, argv_.size() %zu, self_send_threshold "
+      "%d.\n",
+      silent_mctor, size_mcotr, self_send_threshold_ctor);
 
-  MPI_Finalize();
+  return 0;  // should not reach here
 }


### PR DESCRIPTION
I added this test to prove a point that `Mesh` constructors take `Library` pointers and copy them; it requires keeping the `Library` alive during the lifetime of the `Mesh`. I decided to enable it only when Omega_h is built with MPI, since I am checking the library's integrity by accessing the `world_` member with `world()`. The other member functions return static objects, so they are not breaking.