### PR TITLE
Fix unused-but-set-variable warning

### DIFF
--- a/src/Omega_h_memory.hpp
+++ b/src/Omega_h_memory.hpp
@@ -14,7 +14,7 @@ public:
   explicit SharedRef(Args&&... args)
 #if defined(OMEGA_H_COMPILING_FOR_HOST)
       : ptr_(new T(std::forward<Args>(args)...)) {
-    auto [itr, inserted] = refCount_.insert(std::make_pair(ptr_, 1));
+    [[maybe_unused]] auto [itr, inserted] = refCount_.insert(std::make_pair(ptr_, 1));
     assert(inserted);
   }
 #else


### PR DESCRIPTION
Add `[[maybe_unused]]` to fix unused-but-set-variable warning

Note: `[[maybe_unused]]` was added in C++17. @cwsmith Are we still supporting older C++ standards in the current version?