### PR TITLE
Rename warning-as-errors self hosted CI build directory

### DIFF
--- a/.github/workflows/pr_comment_trigger_self_hosted.yml
+++ b/.github/workflows/pr_comment_trigger_self_hosted.yml
@@ -277,7 +277,7 @@ jobs:
           workDir=$OMEGAH_WORK_DIR
 
           # omegah
-          bdir=${workDir}/build-omegah
+          bdir=${workDir}/build-omegah-warning-as-errors
           cmake -S omegah_${{ github.event.issue.number }} -B $bdir \
             -DCMAKE_INSTALL_PREFIX=$bdir/install \
             -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Avoid using the same build directory to solve the issue mentioned in #191 