### PR TITLE
Use explicit capture

### DIFF
--- a/src/Omega_h_comm.cpp
+++ b/src/Omega_h_comm.cpp
@@ -498,7 +498,7 @@ Future<T> Comm::ialltoallv(Read<T> sendbuf_dev, Read<LO> sdispls_dev,
       nonnull(sendbuf.data()), nonnull(sdispls.data()),
       MpiTraits<T>::datatype(), nonnull(recvbuf.data()),
       nonnull(rdispls.data()), MpiTraits<T>::datatype(), impl_);
-  auto callback = [=, this](HostWrite<T> buf) -> Read<T> {
+  auto callback = [this, self_data, rdispls_dev, width](HostWrite<T> buf) -> Read<T> {
     auto recvbuf_dev = Read<T>(buf.write());
     self_send_part2(self_data, self_src_, &recvbuf_dev, rdispls_dev, width);
     return recvbuf_dev;


### PR DESCRIPTION
The previous fix #194 resolved the C++20 warning about implicit capture of `this`. However, it fails with earlier Kokkos versions:
```
/omegah_h/src/Omega_h_comm.cpp(501): error: explicit capture matches default
    auto callback = [=, this](HostWrite<T> buf) -> Read<T> {
                        ^
```
My guess is this may be related to updated C++ standard requirements, but I haven't identified the specific change in Kokkos or build configuration causing this incompatibility. For now, explicit capture of all variables seems to resolve both issues in my tests with SCOREC environment `gcc/13.2.0`. 
