### PR TITLE
Strip windows CR so that it matches in files generated in windows

### DIFF
--- a/src/Omega_h_gmsh.cpp
+++ b/src/Omega_h_gmsh.cpp
@@ -100,6 +100,11 @@ void seek_line(std::istream& stream, std::string const& want) {
   OMEGA_H_CHECK(stream);
   std::string line;
   while (std::getline(stream, line)) {
+    // Strip Windows CR
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+
     if (line == want) {
       break;
     }


### PR DESCRIPTION
I had a Gmsh file generated in Windows 11 with Gmsh Python API, and it wasn't working when I tried `msh2osh`. It could not match the `$FileFormat` line in the file. I am not sure if it is the best solution. But it worked for me. Please suggest if there's any better one. I can also provide a test case if needed.