### PR TITLE
Remove deprecated `Kokkos_ENABLE_CUDA_LAMBDA`

### DIFF
--- a/.github/workflows/pr_comment_trigger_self_hosted.yml
+++ b/.github/workflows/pr_comment_trigger_self_hosted.yml
@@ -101,7 +101,6 @@ jobs:
             -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_OPENMP=off \
             -DKokkos_ENABLE_CUDA=on \
-            -DKokkos_ENABLE_CUDA_LAMBDA=on \
             -DKokkos_ENABLE_DEBUG=off \
             -DCMAKE_INSTALL_PREFIX=$kkbdir/install
           cmake --build $kkbdir --target install -j 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,12 @@ if(Omega_h_USE_Kokkos)
   if ("SYCL" IN_LIST Kokkos_DEVICES)
       bob_option(Omega_h_USE_SYCL "Whether to use SYCL" "ON")
   endif()
+  if (Kokkos_VERSION VERSION_LESS 4.1)
+    if (Kokkos_ENABLE_CUDA AND (NOT "CUDA_LAMBDA" IN_LIST Kokkos_OPTIONS))
+      message(FATAL_ERROR
+              "Please reconfigure Kokkos with -DKokkos_ENABLE_Cuda_Lambda:BOOL=ON")
+    endif()
+  endif()
 endif()
 
 bob_option(Omega_h_MEM_SPACE_SHARED "Whether to use shared memory space" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,6 @@ if(Omega_h_USE_Kokkos)
   if ("SYCL" IN_LIST Kokkos_DEVICES)
       bob_option(Omega_h_USE_SYCL "Whether to use SYCL" "ON")
   endif()
-  if (Kokkos_ENABLE_CUDA AND (NOT "CUDA_LAMBDA" IN_LIST Kokkos_OPTIONS))
-    message(FATAL_ERROR
-            "Please reconfigure Kokkos with -DKokkos_ENABLE_Cuda_Lambda:BOOL=ON")
-  endif()
 endif()
 
 bob_option(Omega_h_MEM_SPACE_SHARED "Whether to use shared memory space" OFF)


### PR DESCRIPTION
`Kokkos_ENABLE_CUDA_LAMBDA` is deprecated since Kokkos 4.1 and has been fully removed. As the oldest Kokkos version currently under maintenance is 4.3, this option should be removed from omega_h.