### PR TITLE
Rename `module` variable in Python API to avoid C++20 keyword conflict

### DIFF
--- a/src/PyOmega_h.cpp
+++ b/src/PyOmega_h.cpp
@@ -1,19 +1,19 @@
 #include <PyOmega_h.hpp>
 
-PYBIND11_MODULE(PyOmega_h, module) {
-  module.doc() = "Omega_h: simplex mesh adaptation";
-  Omega_h::pybind11_defines(module);
-  Omega_h::pybind11_array(module);
-  Omega_h::pybind11_comm(module);
-  Omega_h::pybind11_library(module);
-  Omega_h::pybind11_tag(module);
-  Omega_h::pybind11_graph(module);
-  Omega_h::pybind11_mesh(module);
-  Omega_h::pybind11_build(module);
-  Omega_h::pybind11_adapt(module);
-  Omega_h::pybind11_file(module);
-  Omega_h::pybind11_class(module);
+PYBIND11_MODULE(PyOmega_h, m) {
+  m.doc() = "Omega_h: simplex mesh adaptation";
+  Omega_h::pybind11_defines(m);
+  Omega_h::pybind11_array(m);
+  Omega_h::pybind11_comm(m);
+  Omega_h::pybind11_library(m);
+  Omega_h::pybind11_tag(m);
+  Omega_h::pybind11_graph(m);
+  Omega_h::pybind11_mesh(m);
+  Omega_h::pybind11_build(m);
+  Omega_h::pybind11_adapt(m);
+  Omega_h::pybind11_file(m);
+  Omega_h::pybind11_class(m);
 #ifdef OMEGA_H_USE_DOLFIN
-  Omega_h::pybind11_dolfin(module);
+  Omega_h::pybind11_dolfin(m);
 #endif
 }

--- a/src/PyOmega_h.hpp
+++ b/src/PyOmega_h.hpp
@@ -19,19 +19,19 @@ namespace py = pybind11;
 namespace Omega_h {
 class Library;
 extern Library* pybind11_global_library;
-void pybind11_defines(py::module& module);
-void pybind11_array(py::module& module);
-void pybind11_comm(py::module& module);
-void pybind11_library(py::module& module);
-void pybind11_tag(py::module& module);
-void pybind11_graph(py::module& module);
-void pybind11_mesh(py::module& module);
-void pybind11_build(py::module& module);
-void pybind11_adapt(py::module& module);
-void pybind11_file(py::module& module);
-void pybind11_class(py::module& module);
+void pybind11_defines(py::module& m);
+void pybind11_array(py::module& m);
+void pybind11_comm(py::module& m);
+void pybind11_library(py::module& m);
+void pybind11_tag(py::module& m);
+void pybind11_graph(py::module& m);
+void pybind11_mesh(py::module& m);
+void pybind11_build(py::module& m);
+void pybind11_adapt(py::module& m);
+void pybind11_file(py::module& m);
+void pybind11_class(py::module& m);
 #ifdef OMEGA_H_USE_DOLFIN
-void pybind11_dolfin(py::module& module);
+void pybind11_dolfin(py::module& m);
 #endif
 }  // namespace Omega_h
 

--- a/src/PyOmega_h_adapt.cpp
+++ b/src/PyOmega_h_adapt.cpp
@@ -4,28 +4,28 @@
 
 namespace Omega_h {
 
-void pybind11_adapt(py::module& module) {
+void pybind11_adapt(py::module& m) {
   py::enum_<Verbosity>(
-      module, "Verbosity", "Level of output verbosity in adaptation")
+      m, "Verbosity", "Level of output verbosity in adaptation")
       .value("SILENT", SILENT)
       .value("EACH_ADAPT", EACH_ADAPT)
       .value("EACH_REBUILD", EACH_REBUILD)
       .value("EXTRA_STATS", EXTRA_STATS)
       .export_values();
   py::class_<AdaptOpts>(
-      module, "AdaptOpts", "Options controlling adaptation behavior")
+      m, "AdaptOpts", "Options controlling adaptation behavior")
       .def(py::init<Mesh*>())
       .def_readwrite("verbosity", &AdaptOpts::verbosity)
       .def_readwrite("min_quality_allowed", &AdaptOpts::min_quality_allowed);
   py::class_<MetricSource>(
-      module, "MetricSource", "Describes a single source metric field")
+      m, "MetricSource", "Describes a single source metric field")
       .def(py::init<Omega_h_Source, Real, std::string const&, Omega_h_Isotropy,
                Omega_h_Scales>(),
           "Build a MetricSource", py::arg("type"), py::arg("knob") = 1.0,
           py::arg("tag_name") = "", py::arg("isotropy") = OMEGA_H_ANISOTROPIC,
           py::arg("scales") = OMEGA_H_SCALES);
   py::class_<MetricInput>(
-      module, "MetricInput", "Describes all inputs that form a metric field")
+      m, "MetricInput", "Describes all inputs that form a metric field")
       .def(py::init<>())
       .def_readwrite("verbose", &MetricInput::verbose)
       .def_readwrite("should_limit_lengths", &MetricInput::should_limit_lengths)
@@ -44,15 +44,15 @@ void pybind11_adapt(py::module& module) {
           &MetricInput::element_count_over_relaxation)
       .def_readwrite("nsmoothing_steps", &MetricInput::nsmoothing_steps)
       .def("add_source", &MetricInput::add_source);
-  module.def("grade_fix_adapt", &grade_fix_adapt,
+  m.def("grade_fix_adapt", &grade_fix_adapt,
       "Apply gradation control, possibly fix quality, then adapt",
       py::arg("mesh"), py::arg("opts"), py::arg("target_metric"),
       py::arg("verbose") = true);
-  module.def("add_implied_metric_tag", &add_implied_metric_tag);
-  module.def("generate_target_metric_tag", &generate_target_metric_tag);
-  module.def("approach_metric", &approach_metric, py::arg("mesh"),
+  m.def("add_implied_metric_tag", &add_implied_metric_tag);
+  m.def("generate_target_metric_tag", &generate_target_metric_tag);
+  m.def("approach_metric", &approach_metric, py::arg("mesh"),
       py::arg("opts"), py::arg("min_step") = 1e-4);
-  module.def("adapt", &adapt);
+  m.def("adapt", &adapt);
 }
 
 }  // namespace Omega_h

--- a/src/PyOmega_h_array.cpp
+++ b/src/PyOmega_h_array.cpp
@@ -4,24 +4,24 @@
 namespace Omega_h {
 
 template <class Scalar, class Wrapper>
-static void pybind11_array_type(py::module& module,
+static void pybind11_array_type(py::module& m,
     std::string const& py_scalar, std::string const& py_wrapper) {
   auto write_name = std::string("Write_") + py_scalar;
   auto read_name = std::string("Read_") + py_scalar;
   auto hostread_name = std::string("HostRead_") + py_scalar;
   auto hostwrite_name = std::string("HostWrite_") + py_scalar;
   auto deepcopy_name = std::string("deep_copy_") + py_scalar;
-  py::class_<Write<Scalar>>(module, write_name.c_str())
+  py::class_<Write<Scalar>>(m, write_name.c_str())
       .def("size", &Write<Scalar>::size);
-  py::class_<Read<Scalar>>(module, read_name.c_str())
+  py::class_<Read<Scalar>>(m, read_name.c_str())
       .def(py::init<Write<Scalar>>())
       .def("size", &Read<Scalar>::size)
       .def(py::init<LO, Scalar, std::string const&>(), py::arg("size"),
           py::arg("value"), py::arg("name") = "");
   // Create an alias for the wrapper name
-  module.attr(py_wrapper.c_str()) = module.attr(read_name.c_str());
+  m.attr(py_wrapper.c_str()) = m.attr(read_name.c_str());
   py::class_<HostRead<Scalar>>(
-      module, hostread_name.c_str(), py::buffer_protocol())
+      m, hostread_name.c_str(), py::buffer_protocol())
       .def(py::init<Read<Scalar>>())
       .def_buffer([](HostRead<Scalar>& a) -> py::buffer_info {
         return py::buffer_info(
@@ -33,7 +33,7 @@ static void pybind11_array_type(py::module& module,
       })
       .def("get", &HostRead<Scalar>::get);
   py::class_<HostWrite<Scalar>>(
-      module, hostwrite_name.c_str(), py::buffer_protocol())
+      m, hostwrite_name.c_str(), py::buffer_protocol())
       .def(py::init<LO, std::string const&>(), py::arg("size"),
           py::arg("name") = "")
       .def_buffer([](HostWrite<Scalar>& a) -> py::buffer_info {
@@ -46,15 +46,15 @@ static void pybind11_array_type(py::module& module,
       .def("write", &HostWrite<Scalar>::write);
   Write<Scalar> (*deep_copy_type)(Read<Scalar> a, std::string const&) =
       &deep_copy;
-  module.def(deepcopy_name.c_str(), deep_copy_type, py::arg("a"),
+  m.def(deepcopy_name.c_str(), deep_copy_type, py::arg("a"),
       py::arg("name") = "");
 }
 
-void pybind11_array(py::module& module) {
-  pybind11_array_type<I8, Bytes>(module, "int8", "Bytes");
-  pybind11_array_type<I32, LOs>(module, "int32", "LOs");
-  pybind11_array_type<I64, GOs>(module, "int64", "GOs");
-  pybind11_array_type<Real, Reals>(module, "float64", "Reals");
+void pybind11_array(py::module& m) {
+  pybind11_array_type<I8, Bytes>(m, "int8", "Bytes");
+  pybind11_array_type<I32, LOs>(m, "int32", "LOs");
+  pybind11_array_type<I64, GOs>(m, "int64", "GOs");
+  pybind11_array_type<Real, Reals>(m, "float64", "Reals");
 }
 
 }  // namespace Omega_h

--- a/src/PyOmega_h_build.cpp
+++ b/src/PyOmega_h_build.cpp
@@ -3,8 +3,8 @@
 
 namespace Omega_h {
 
-void pybind11_build(py::module& module) {
-  module.def("build_box", &Omega_h::build_box, "Build a rectangular mesh",
+void pybind11_build(py::module& m) {
+  m.def("build_box", &Omega_h::build_box, "Build a rectangular mesh",
       // if we give this a default argument, its lifetime is that
       // of a global variable, which exceeds the Library lifetime!
       py::arg("comm") /*= pybind11_global_library->world()*/,

--- a/src/PyOmega_h_class.cpp
+++ b/src/PyOmega_h_class.cpp
@@ -4,8 +4,8 @@
 
 namespace Omega_h {
 
-void pybind11_class(py::module& module) {
-  module.def("classify_by_angles", &Omega_h::classify_by_angles,
+void pybind11_class(py::module& m) {
+  m.def("classify_by_angles", &Omega_h::classify_by_angles,
       "Classify a mesh, sharp-angle creases become corners/curves",
       py::arg("mesh"), py::arg("sharp_angle"));
 }

--- a/src/PyOmega_h_comm.cpp
+++ b/src/PyOmega_h_comm.cpp
@@ -5,13 +5,13 @@
 
 namespace Omega_h {
 
-void pybind11_comm(py::module& module) {
+void pybind11_comm(py::module& m) {
   // Bind the Comm class
 #ifdef OMEGA_H_USE_MPI
   using CommHandle = std::uintptr_t;
 #endif
 
-  py::class_<Omega_h::Comm, std::shared_ptr<Omega_h::Comm>>(module, "Comm")
+  py::class_<Omega_h::Comm, std::shared_ptr<Omega_h::Comm>>(m, "Comm")
   // Constructors
 #ifdef OMEGA_H_USE_MPI
     .def(py::init([](Omega_h::Library* library, CommHandle impl_handle) {

--- a/src/PyOmega_h_defines.cpp
+++ b/src/PyOmega_h_defines.cpp
@@ -3,31 +3,31 @@
 
 namespace Omega_h {
 
-void pybind11_defines(py::module& module) {
-  py::enum_<Omega_h_Type>(module, "Type")
+void pybind11_defines(py::module& m) {
+  py::enum_<Omega_h_Type>(m, "Type")
       .value("I8", OMEGA_H_I8)
       .value("I32", OMEGA_H_I32)
       .value("I64", OMEGA_H_I64)
       .value("F64", OMEGA_H_F64)
       .value("REAL", OMEGA_H_REAL)
       .export_values();
-  py::enum_<Omega_h_EntDim>(module, "EntDim", py::arithmetic())
+  py::enum_<Omega_h_EntDim>(m, "EntDim", py::arithmetic())
       .value("VERT", OMEGA_H_VERT)
       .value("EDGE", OMEGA_H_EDGE)
       .value("FACE", OMEGA_H_FACE)
       .value("REGION", OMEGA_H_REGION)
       .export_values();
-  py::enum_<Omega_h_Op>(module, "Op")
+  py::enum_<Omega_h_Op>(m, "Op")
       .value("MIN", OMEGA_H_MIN)
       .value("MAX", OMEGA_H_MAX)
       .value("SUM", OMEGA_H_SUM)
       .export_values();
-  py::enum_<Omega_h_Comparison>(module, "Comparison")
+  py::enum_<Omega_h_Comparison>(m, "Comparison")
       .value("SAME", OMEGA_H_SAME)
       .value("MORE", OMEGA_H_MORE)
       .value("DIFF", OMEGA_H_DIFF)
       .export_values();
-  py::enum_<Omega_h_Transfer>(module, "Transfer")
+  py::enum_<Omega_h_Transfer>(m, "Transfer")
       .value("INHERIT", OMEGA_H_INHERIT)
       .value("LINEAR_INTERP", OMEGA_H_LINEAR_INTERP)
       .value("METRIC", OMEGA_H_METRIC)
@@ -36,13 +36,13 @@ void pybind11_defines(py::module& module) {
       .value("MOMENTUM_VELOCITY", OMEGA_H_MOMENTUM_VELOCITY)
       .value("POINTWISE", OMEGA_H_POINTWISE)
       .export_values();
-  py::enum_<Omega_h_Parting>(module, "Parting")
+  py::enum_<Omega_h_Parting>(m, "Parting")
       .value("ELEM_BASED", OMEGA_H_ELEM_BASED)
       .value("GHOSTED", OMEGA_H_GHOSTED)
       .value("VERT_BASED", OMEGA_H_VERT_BASED)
       .export_values();
   py::enum_<Omega_h_Source>(
-      module, "Source", "The type of source of a metric field")
+      m, "Source", "The type of source of a metric field")
       .value("CONSTANT", OMEGA_H_CONSTANT)
       .value("VARIATION", OMEGA_H_VARIATION)
       .value("DERIVATIVE", OMEGA_H_DERIVATIVE)
@@ -50,24 +50,24 @@ void pybind11_defines(py::module& module) {
       .value("IMPLIED", OMEGA_H_IMPLIED)
       .value("CURVATURE", OMEGA_H_CURVATURE)
       .export_values();
-  py::enum_<Omega_h_Isotropy>(module, "Isotropy",
+  py::enum_<Omega_h_Isotropy>(m, "Isotropy",
       "Whether and how to convert an anisotropic metric into an isotropic one")
       .value("ANISOTROPIC", OMEGA_H_ANISOTROPIC)
       .value("ISO_LENGTH", OMEGA_H_ISO_LENGTH)
       .value("ISO_SIZE", OMEGA_H_ISO_SIZE)
       .export_values();
-  py::enum_<Omega_h_Scales>(module, "Scales",
+  py::enum_<Omega_h_Scales>(m, "Scales",
       "Whether a metric source scales to satisfy element counts")
       .value("ABSOLUTE", OMEGA_H_ABSOLUTE)
       .value("SCALES", OMEGA_H_SCALES)
       .export_values();
   py::enum_<Omega_h_Family>(
-      module, "Family", "Whether elements are simplices, hypercubes, or mixed")
+      m, "Family", "Whether elements are simplices, hypercubes, or mixed")
       .value("SIMPLEX", OMEGA_H_SIMPLEX)
       .value("HYPERCUBE", OMEGA_H_HYPERCUBE)
       .value("MIXED", OMEGA_H_MIXED)
       .export_values();
-  py::enum_<Topo_type>(module, "TopoType")
+  py::enum_<Topo_type>(m, "TopoType")
       .value("vertex", Topo_type::vertex)
       .value("edge", Topo_type::edge)
       .value("triangle", Topo_type::triangle)

--- a/src/PyOmega_h_dolfin.cpp
+++ b/src/PyOmega_h_dolfin.cpp
@@ -3,20 +3,20 @@
 
 namespace Omega_h {
 
-void pybind11_dolfin(py::module& module) {
+void pybind11_dolfin(py::module& m) {
   void (*mesh_from_dolfin)(Mesh*, dolfin::Mesh const&) = &from_dolfin;
   void (*function_from_dolfin)(
       Mesh*, dolfin::Function const&, std::string const&) = &from_dolfin;
-  module.def(
+  m.def(
       "mesh_to_dolfin", &to_dolfin, "Convert an Omega_h mesh to a DOLFIN mesh");
-  module.def("mesh_from_dolfin", mesh_from_dolfin,
+  m.def("mesh_from_dolfin", mesh_from_dolfin,
       "Convert a DOLFIN mesh to an Omega_h mesh");
-  module.def("mesh_from_dolfin_unit_square",
+  m.def("mesh_from_dolfin_unit_square",
       [](Mesh* mesh_osh, std::shared_ptr<dolfin::UnitSquareMesh>* mesh_dolfin) {
         from_dolfin(mesh_osh, *(*mesh_dolfin));
       },
       "Convert a DOLFIN UnitSquareMesh to an Omega_h mesh");
-  module.def("function_from_dolfin", function_from_dolfin,
+  m.def("function_from_dolfin", function_from_dolfin,
       "Convert a DOLFIN Function to Omega_h tag(s)");
 }
 

--- a/src/PyOmega_h_file.cpp
+++ b/src/PyOmega_h_file.cpp
@@ -8,10 +8,10 @@
 
 namespace Omega_h {
 
-void pybind11_file(py::module& module) {
-  py::class_<Omega_h::filesystem::path>(module, "path")
+void pybind11_file(py::module& m) {
+  py::class_<Omega_h::filesystem::path>(m, "path")
       .def(py::init<char const*>());
-  module.def(
+  m.def(
     "read_mesh_file",
     [](const std::string& filepath, std::shared_ptr<Omega_h::Comm> comm) {
       return Omega_h::read_mesh_file(filepath, comm);
@@ -20,7 +20,7 @@ void pybind11_file(py::module& module) {
     "Read mesh from file (auto-detects format)", py::return_value_policy::move);
 
   // Binary format I/O
-  module.def(
+  m.def(
     "read_mesh_binary",
     [](const std::string& filepath, Omega_h::Library* lib) {
       Omega_h::Mesh mesh(lib);
@@ -30,7 +30,7 @@ void pybind11_file(py::module& module) {
     py::arg("filepath"), py::arg("library"), "Read mesh from binary file",
     py::return_value_policy::move);
 
-  module.def(
+  m.def(
     "read_mesh_binary",
     [](const std::string& filepath, std::shared_ptr<Omega_h::Comm> comm) {
       return Omega_h::binary::read(filepath, comm);
@@ -38,7 +38,7 @@ void pybind11_file(py::module& module) {
     py::arg("filepath"), py::arg("comm"), "Read mesh from binary file",
     py::return_value_policy::move);
 
-  module.def(
+  m.def(
     "write_mesh_binary",
     [](const std::string& filepath, Omega_h::Mesh& mesh) {
       Omega_h::binary::write(filepath, &mesh);
@@ -46,7 +46,7 @@ void pybind11_file(py::module& module) {
     py::arg("filepath"), py::arg("mesh"), "Write mesh to binary file");
 
   // Gmsh format I/O
-  module.def(
+  m.def(
     "read_mesh_gmsh",
     [](const std::string& filepath, std::shared_ptr<Omega_h::Comm> comm) {
       return Omega_h::gmsh::read(filepath, comm);
@@ -54,7 +54,7 @@ void pybind11_file(py::module& module) {
     py::arg("filepath"), py::arg("comm"), "Read mesh from Gmsh file",
     py::return_value_policy::move);
 
-  module.def(
+  m.def(
     "write_mesh_gmsh",
     [](const std::string& filepath, Omega_h::Mesh& mesh) {
       Omega_h::gmsh::write(filepath, &mesh);
@@ -62,7 +62,7 @@ void pybind11_file(py::module& module) {
     py::arg("filepath"), py::arg("mesh"), "Write mesh to Gmsh file");
 
 #ifdef OMEGA_H_USE_GMSH
-  module.def(
+  m.def(
     "read_mesh_gmsh_parallel",
     [](const std::string& filepath, std::shared_ptr<Omega_h::Comm> comm) {
       return Omega_h::gmsh::read_parallel(filepath, comm);
@@ -70,12 +70,12 @@ void pybind11_file(py::module& module) {
     py::arg("filepath"), py::arg("comm"), "Read parallel Gmsh mesh (MSH 4.1+)",
     py::return_value_policy::move);
 
-  module.def("write_mesh_gmsh_parallel", &Omega_h::gmsh::write_parallel,
+  m.def("write_mesh_gmsh_parallel", &Omega_h::gmsh::write_parallel,
     py::arg("filepath"), py::arg("mesh"), "Write parallel Gmsh mesh (MSH 4.1)");
 #endif
 
   // VTK format I/O
-  module.def(
+  m.def(
     "write_mesh_vtu",
     [](const std::string& filepath, Omega_h::Mesh& mesh, bool compress) {
       Omega_h::vtk::write_vtu(filepath, &mesh, compress);
@@ -83,7 +83,7 @@ void pybind11_file(py::module& module) {
     py::arg("filepath"), py::arg("mesh"),
     py::arg("compress") = OMEGA_H_DEFAULT_COMPRESS, "Write mesh to VTU file");
 
-  module.def(
+  m.def(
     "write_mesh_vtu",
     [](const std::string& filepath, Omega_h::Mesh& mesh, Omega_h::Int cell_dim,
        bool compress) {
@@ -93,7 +93,7 @@ void pybind11_file(py::module& module) {
     py::arg("compress") = OMEGA_H_DEFAULT_COMPRESS,
     "Write mesh to VTU file with specified cell dimension");
 
-  module.def(
+  m.def(
     "write_mesh_parallel_vtk",
     [](const std::string& filepath, Omega_h::Mesh& mesh, bool compress) {
       Omega_h::vtk::write_parallel(filepath, &mesh, compress);
@@ -102,7 +102,7 @@ void pybind11_file(py::module& module) {
     py::arg("compress") = OMEGA_H_DEFAULT_COMPRESS,
     "Write mesh to parallel VTK files");
 
-  module.def(
+  m.def(
     "read_mesh_parallel_vtk",
     [](const std::string& pvtupath, std::shared_ptr<Omega_h::Comm> comm) {
       Omega_h::Mesh mesh;
@@ -114,13 +114,13 @@ void pybind11_file(py::module& module) {
 
 #ifdef OMEGA_H_USE_SEACASEXODUS
   // Exodus ClassifyWith enum
-  py::enum_<Omega_h::exodus::ClassifyWith>(module, "ExodusClassifyWith")
+  py::enum_<Omega_h::exodus::ClassifyWith>(m, "ExodusClassifyWith")
     .value("NODE_SETS", Omega_h::exodus::NODE_SETS)
     .value("SIDE_SETS", Omega_h::exodus::SIDE_SETS)
     .export_values();
 
   // Exodus file operations
-  module.def(
+  m.def(
     "exodus_open",
     [](const std::string& filepath, bool verbose) {
       return Omega_h::exodus::open(filepath, verbose);
@@ -128,19 +128,19 @@ void pybind11_file(py::module& module) {
     py::arg("filepath"), py::arg("verbose") = false,
     "Open an Exodus file and return file handle");
 
-  module.def(
+  m.def(
     "exodus_close",
     [](int exodus_file) { Omega_h::exodus::close(exodus_file); },
     py::arg("exodus_file"), "Close an Exodus file");
 
-  module.def(
+  m.def(
     "exodus_get_num_time_steps",
     [](int exodus_file) {
       return Omega_h::exodus::get_num_time_steps(exodus_file);
     },
     py::arg("exodus_file"), "Get the number of time steps in an Exodus file");
 
-  module.def(
+  m.def(
     "read_mesh_exodus",
     [](int exodus_file, Omega_h::Mesh& mesh, bool verbose, int classify_with) {
       Omega_h::exodus::read_mesh(exodus_file, &mesh, verbose, classify_with);
@@ -150,7 +150,7 @@ void pybind11_file(py::module& module) {
       Omega_h::exodus::NODE_SETS | Omega_h::exodus::SIDE_SETS,
     "Read mesh from an open Exodus file");
 
-  module.def(
+  m.def(
     "read_exodus_nodal_fields",
     [](int exodus_file, Omega_h::Mesh& mesh, int time_step,
        const std::string& prefix, const std::string& postfix, bool verbose) {
@@ -161,7 +161,7 @@ void pybind11_file(py::module& module) {
     py::arg("prefix") = "", py::arg("postfix") = "", py::arg("verbose") = false,
     "Read nodal fields from an open Exodus file at a specific time step");
 
-  module.def(
+  m.def(
     "read_exodus_element_fields",
     [](int exodus_file, Omega_h::Mesh& mesh, int time_step,
        const std::string& prefix, const std::string& postfix, bool verbose) {
@@ -172,7 +172,7 @@ void pybind11_file(py::module& module) {
     py::arg("prefix") = "", py::arg("postfix") = "", py::arg("verbose") = false,
     "Read element fields from an open Exodus file at a specific time step");
 
-  module.def(
+  m.def(
     "read_mesh_exodus_sliced",
     [](const std::string& filepath, std::shared_ptr<Omega_h::Comm> comm,
        bool verbose, int classify_with, int time_step) {
@@ -185,7 +185,7 @@ void pybind11_file(py::module& module) {
     py::arg("time_step") = -1, "Read sliced Exodus mesh in parallel",
     py::return_value_policy::move);
 
-  module.def(
+  m.def(
     "write_mesh_exodus",
     [](const std::string& filepath, Omega_h::Mesh& mesh, bool verbose,
        int classify_with) {
@@ -199,14 +199,14 @@ void pybind11_file(py::module& module) {
 
 #ifdef OMEGA_H_USE_LIBMESHB
   // MESHB format I/O
-  module.def(
+  m.def(
     "read_mesh_meshb",
     [](Omega_h::Mesh& mesh, const std::string& filepath) {
       Omega_h::meshb::read(&mesh, filepath);
     },
     py::arg("mesh"), py::arg("filepath"), "Read mesh from MESHB file");
 
-  module.def(
+  m.def(
     "write_mesh_meshb",
     [](Omega_h::Mesh& mesh, const std::string& filepath, int version) {
       Omega_h::meshb::write(&mesh, filepath, version);
@@ -214,7 +214,7 @@ void pybind11_file(py::module& module) {
     py::arg("mesh"), py::arg("filepath"), py::arg("version") = 2,
     "Write mesh to MESHB file");
 
-  module.def(
+  m.def(
     "read_meshb_sol",
     [](Omega_h::Mesh& mesh, const std::string& filepath,
        const std::string& sol_name) {
@@ -223,7 +223,7 @@ void pybind11_file(py::module& module) {
     py::arg("mesh"), py::arg("filepath"), py::arg("sol_name"),
     "Read solution/resolution data from MESHB .sol file");
 
-  module.def(
+  m.def(
     "write_meshb_sol",
     [](Omega_h::Mesh& mesh, const std::string& filepath,
        const std::string& sol_name, int version) {
@@ -236,7 +236,7 @@ void pybind11_file(py::module& module) {
 
 #ifdef OMEGA_H_USE_ADIOS2
   // ADIOS2 format I/O
-  module.def(
+  m.def(
     "read_mesh_adios2",
     [](const std::string& filepath, Omega_h::Library* lib,
        const std::string& prefix) {
@@ -245,7 +245,7 @@ void pybind11_file(py::module& module) {
     py::arg("filepath"), py::arg("library"), py::arg("prefix") = "",
     "Read mesh from ADIOS2 file", py::return_value_policy::move);
 
-  module.def(
+  m.def(
     "write_mesh_adios2",
     [](const std::string& filepath, Omega_h::Mesh& mesh,
        const std::string& prefix) {

--- a/src/PyOmega_h_graph.cpp
+++ b/src/PyOmega_h_graph.cpp
@@ -4,8 +4,8 @@
 
 
 namespace Omega_h {
-void pybind11_graph(py::module& module) {
-  py::class_<Omega_h::Graph>(module, "OmegaHGraph")
+void pybind11_graph(py::module& m) {
+  py::class_<Omega_h::Graph>(m, "OmegaHGraph")
     .def_property(
       "a2ab",
       [](const Omega_h::Graph& graph) {

--- a/src/PyOmega_h_library.cpp
+++ b/src/PyOmega_h_library.cpp
@@ -19,10 +19,10 @@ namespace Omega_h {
 
 Library* pybind11_global_library = nullptr;
 
-void pybind11_library(py::module& module) {
+void pybind11_library(py::module& m) {
   // Bind Omega_h::Library
   py::class_<Omega_h::Library>(
-    module, "OmegaHLibrary")
+    m, "OmegaHLibrary")
     .def(py::init<>(), "Default constructor")
     .def("world", &Omega_h::Library::world, "Get the world communicator");
 }

--- a/src/PyOmega_h_mesh.cpp
+++ b/src/PyOmega_h_mesh.cpp
@@ -17,10 +17,10 @@ namespace Omega_h {
           py::arg("internal_do_not_use_ever") = false)
 
 
-void pybind11_mesh(py::module& module) {
+void pybind11_mesh(py::module& m) {
   void (Mesh::*set_parting)(Omega_h_Parting, Int, bool) = &Mesh::set_parting;
   void (Mesh::*balance)(bool) = &Mesh::balance;
-  py::class_<Omega_h::Mesh, std::shared_ptr<Omega_h::Mesh>>(module, "OmegaHMesh")
+  py::class_<Omega_h::Mesh, std::shared_ptr<Omega_h::Mesh>>(m, "OmegaHMesh")
     .def(py::init<>(), "Default constructor")
     .def(py::init<Omega_h::Library*>(), py::arg("library"),
          "Constructor with library")
@@ -458,10 +458,10 @@ void pybind11_mesh(py::module& module) {
         return omega_h_read_to_numpy(sizes);
       },
       "Get element sizes");
-  module.def(
+  m.def(
       "new_empty_mesh", []() { return Mesh(pybind11_global_library); });
   // Mesh utility functions
-  module.def(
+  m.def(
     "average_field",
     [](Omega_h::Mesh* mesh, Omega_h::Int dim, Omega_h::Int ncomps,
        py::array_t<Omega_h::Real> v2x) {
@@ -474,7 +474,7 @@ void pybind11_mesh(py::module& module) {
     "Average vertex field data to entity centers (e.g., get face coordinates "
     "from vertex coordinates)");
 
-  module.def(
+  m.def(
     "average_field",
     [](Omega_h::Mesh* mesh, Omega_h::Int dim, py::array_t<Omega_h::LO> a2e,
        Omega_h::Int ncomps, py::array_t<Omega_h::Real> v2x) {

--- a/src/PyOmega_h_tag.cpp
+++ b/src/PyOmega_h_tag.cpp
@@ -3,15 +3,15 @@
 #include <PyOmega_h.hpp>
 
 namespace Omega_h {
-void pybind11_tag(py::module& module) {
+void pybind11_tag(py::module& m) {
    // Bind ArrayType enum for tag array types
-  py::enum_<Omega_h::ArrayType>(module, "ArrayType")
+  py::enum_<Omega_h::ArrayType>(m, "ArrayType")
     .value("VectorND", Omega_h::ArrayType::VectorND)
     .value("SymmetricSquareMatrix", Omega_h::ArrayType::SymmetricSquareMatrix)
     .export_values();
 
   // Bind TagBase class for tag metadata access
-  py::class_<Omega_h::TagBase>(module, "TagBase")
+  py::class_<Omega_h::TagBase>(m, "TagBase")
     .def("name", &Omega_h::TagBase::name, "Get tag name")
     .def("ncomps", &Omega_h::TagBase::ncomps, "Get number of components")
     .def("type", &Omega_h::TagBase::type, "Get tag data type (Omega_h_Type)")


### PR DESCRIPTION
The variable `module` is compiled as a reserved keyword in C++20, causing compilation errors when building the Python API in c++ 20.