### PR TITLE
don't require SimPartitionedMesh-mpi and friends

### DIFF
--- a/.github/workflows/pr_comment_trigger_self_hosted.yml
+++ b/.github/workflows/pr_comment_trigger_self_hosted.yml
@@ -154,7 +154,6 @@ jobs:
             -DOmega_h_USE_SimModSuite=on \
             -DOmega_h_USE_SimDiscrete=on \
             -DSKIP_SIMMETRIX_VERSION_CHECK=on \
-            -DSIM_MPI=mpich4.2.3 \
             -DOmega_h_USE_Kokkos=on \
             -DOmega_h_CUDA_ARCH="80" \
             -DCMAKE_CUDA_ARCHITECTURES="80" \
@@ -188,7 +187,6 @@ jobs:
             -DOmega_h_USE_SimModSuite=on \
             -DOmega_h_USE_SimDiscrete=on \
             -DSKIP_SIMMETRIX_VERSION_CHECK=on \
-            -DSIM_MPI=mpich4.2.3 \
             -DOmega_h_USE_Kokkos=off \
             -DOmega_h_USE_ADIOS2=ON \
             -DOmega_h_USE_Gmsh=ON \
@@ -220,7 +218,6 @@ jobs:
             -DOmega_h_USE_SimModSuite=on \
             -DOmega_h_USE_SimDiscrete=on \
             -DSKIP_SIMMETRIX_VERSION_CHECK=on \
-            -DSIM_MPI=mpich4.2.3 \
             -DOmega_h_USE_Kokkos=on \
             -DKokkos_PREFIX=${KOKKOS_SERIAL_BUILD}/install \
             -DOmega_h_USE_ADIOS2=ON \
@@ -253,7 +250,6 @@ jobs:
             -DOmega_h_USE_SimModSuite=on \
             -DOmega_h_USE_SimDiscrete=on \
             -DSKIP_SIMMETRIX_VERSION_CHECK=on \
-            -DSIM_MPI=mpich4.2.3 \
             -DOmega_h_USE_Kokkos=on \
             -DKokkos_PREFIX=${KOKKOS_OPENMP_BUILD}/install \
             -DOmega_h_USE_ADIOS2=ON \
@@ -317,7 +313,6 @@ jobs:
             -DOmega_h_USE_SimModSuite=on \
             -DOmega_h_USE_SimDiscrete=on \
             -DSKIP_SIMMETRIX_VERSION_CHECK=on \
-            -DSIM_MPI=mpich4.2.3 \
             -DOmega_h_USE_Kokkos=on \
             -DOmega_h_CUDA_ARCH="80" \
             -DCMAKE_CUDA_ARCHITECTURES="80" \

--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -8,7 +8,6 @@
 #  SIMMODSUITE_MINOR_VERSION - the date code from the version string
 #
 # Based on input variables:
-#  SIM_MPI
 #  SIMMETRIX_LIB_DIR
 #  SIMMETRIX_INCLUDE_DIR
 # And environment variable:
@@ -18,13 +17,6 @@
 # VERSION/
 #         include/*.h
 #         lib/ARCHOS/*.a
-
-if (Omega_h_USE_MPI)
-  set(SIM_MPI "" CACHE STRING "MPI implementation used for SimPartitionWrapper")
-  if(SIM_MPI MATCHES "^$")
-    message(FATAL_ERROR "SIM_MPI is not defined... libSimPartitionWrapper-$SIM_MPI.a should exist in the SimModSuite lib directory")
-  endif()
-endif()
 
 macro(simLibCheckBootstrap libs)
   simLibCheck(${libs} TRUE)
@@ -111,11 +103,7 @@ message(STATUS "Building with SimModSuite ${SIM_DOT_VERSION}")
 
 set(SIMMODSUITE_LIBS "")
 
-if (Omega_h_USE_MPI)
-  set(SIM_BOOTSTRAP_LIB_NAME SimPartitionedMesh-mpi)
-else()
-  set(SIM_BOOTSTRAP_LIB_NAME SimPartitionedMesh)
-endif()
+set(SIM_BOOTSTRAP_LIB_NAME SimPartitionedMesh)
 
 simLibCheckBootstrap("${SIM_BOOTSTRAP_LIB_NAME}")
 
@@ -168,11 +156,9 @@ simLibCheck("${SIM_OPT_LIB_NAMES}" FALSE)
 
 if (Omega_h_USE_MPI)
   set(SIM_CORE_LIB_NAMES
-    SimPartitionedMesh-mpi
     SimMeshing
     SimMeshTools
-    SimModel
-    SimPartitionWrapper-${SIM_MPI})
+    SimModel)
 else()
   set(SIM_CORE_LIB_NAMES
     SimMeshing


### PR DESCRIPTION
We don't use simmodsuite partitioned mesh apis and some of our users don't have the parallel simmetrix license.