### PR TITLE
Preserve exodus nodesets as vertices tags

### DIFF
--- a/src/Omega_h_exodus.cpp
+++ b/src/Omega_h_exodus.cpp
@@ -340,10 +340,12 @@ void read_mesh(int file, Mesh* mesh, bool verbose, int classify_with) {
   std::vector<int> side_set_ids(std::size_t(init_params.num_side_sets));
   CALL(ex_get_ids(file, EX_SIDE_SET, side_set_ids.data()));
   Write<LO> side_class_ids_w(mesh->nents(dim - 1), -1);
+  Write<LO> node_class_ids_w(mesh->nents(0), -1);
   auto sides_are_exposed = mark_exposed_sides(mesh);
   classify_sides_by_exposure(mesh, sides_are_exposed);
   Write<I8> side_class_dims_w =
       deep_copy(mesh->get_array<I8>(dim - 1, "class_dim"));
+  Write<I8> node_class_dims_w (mesh->nents(0),-1);
   auto exposed_sides2side = collect_marked(sides_are_exposed);
   map_value_into(0, exposed_sides2side, side_class_ids_w);
   if ((classify_with & NODE_SETS) && init_params.num_node_sets) {
@@ -375,17 +377,14 @@ void read_mesh(int file, Mesh* mesh, bool verbose, int classify_with) {
       auto set_nodes2nodes =
           subtract_from_each(LOs(h_set_nodes2nodes.write()), 1);
       auto nodes_are_in_set = mark_image(set_nodes2nodes, mesh->nverts());
-      auto sides_are_in_set =
-          mark_up_all(mesh, VERT, dim - 1, nodes_are_in_set);
-      auto set_sides2side = collect_marked(sides_are_in_set);
-      auto surface_id = node_set_ids[i] + max_side_set_id;
+      auto node_collection_id = node_set_ids[i] + max_side_set_id;
       if (verbose) {
         std::cout << "P" << mesh->comm()->rank() << ": node set #" << node_set_ids[i] << " \"" << name_ptrs[i]
-                  << "\" will be surface " << surface_id << std::endl;
+                  << "\" will be node_collection " << node_collection_id << std::endl;
       }
-      map_value_into(surface_id, set_sides2side, side_class_ids_w);
-      map_value_into(I8(dim - 1), set_sides2side, side_class_dims_w);
-      mesh->class_sets[name_ptrs[i]].push_back({I8(dim - 1), surface_id});
+      map_value_into(node_collection_id, set_nodes2nodes, node_class_ids_w);
+      map_value_into(I8(0), set_nodes2nodes, node_class_dims_w);
+      mesh->class_sets[name_ptrs[i]].push_back({I8(0), node_collection_id});
     }
   }
   if (classify_with & SIDE_SETS) {
@@ -431,9 +430,13 @@ void read_mesh(int file, Mesh* mesh, bool verbose, int classify_with) {
   auto elem_class_ids = LOs(elem_class_ids_w);
   auto side_class_ids = LOs(side_class_ids_w);
   auto side_class_dims = Read<I8>(side_class_dims_w);
+  auto node_class_ids = LOs(node_class_ids_w);
+  auto node_class_dims = Read<I8>(node_class_dims_w);
   mesh->add_tag(dim, "class_id", 1, elem_class_ids);
   mesh->add_tag(dim - 1, "class_id", 1, side_class_ids);
   mesh->set_tag(dim - 1, "class_dim", side_class_dims);
+  mesh->add_tag(0, "class_id", 0, node_class_ids);
+  mesh->add_tag(0, "class_dim", 0, node_class_dims);
   finalize_classification(mesh);
   end_code();
 }


### PR DESCRIPTION
When parsing exodus files, nodesets should not be classified as sidesets, as that can backfire in case a side has both nodes in the sideset, even though the side itsefl is an internal side.

E.g., consider a square cut in 2 triangles, with all nodes on the "boundary" nodeset. By marking up the nodes, the diagonal side in the square gets marked as part of the classification, which is intrinsically wrong.

The approach in this PR keeps exodus nodesets relegated to vertices tags, without even trying to create a side classification. If this approach is not desirable, we could keep the master impl, but add a step that, after the mark_up_all call, removes the sides that are not exposed. However, this is somewhat arbitrary, as exodus technically allows to define nodesets that are inside the mesh volume (they are an arbitrary collection of nodes), and may not map to a boundary surface (or to a surface at all).

@cwsmith let me know what your thoughts are. We don't need to merge this, but we need to do some change to exo2osh. I am not super confident that what I did makes sense, as I got lost in omegah classification semantics/logic here.

To be clear: with this modification, the humboldt mesh that albany uses can correctly be converted to an osh mesh that does not wrongly declare an inner side as part of `boundary_node_set_3`.