### PR TITLE
fix gpu builds on SCOREC with python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ set(SEACASExodus_PREFIX_DEFAULT ${Trilinos_PREFIX})
 bob_add_dependency(PUBLIC NAME SEACASExodus TARGETS SEACASExodus::all_libs)
 
 set(Omega_h_USE_pybind11_DEFAULT OFF)
-bob_public_dep(pybind11)
+bob_private_dep(pybind11)
 
 if(Omega_h_USE_Kokkos)
   bob_option(Omega_h_USE_Kokkos_Sort "Use Kokkos sort_by_key instead of vendor (Thrust, SYCL, etc.) provided sorting APIs." ON)
@@ -157,6 +157,7 @@ set(Omega_h_KEY_BOOLS
     Omega_h_USE_ADIOS2
     Omega_h_USE_DOLFIN
     Omega_h_USE_dwarf
+    Omega_h_USE_pybind11
     Omega_h_CHECK_BOUNDS
     Omega_h_THROW
     OMEGA_H_USE_GPU_AWARE_MPI

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -885,7 +885,15 @@ if (Omega_h_USE_pybind11)
   if (Omega_h_USE_DOLFIN)
     list(APPEND PYBIND11_SOURCES PyOmega_h_dolfin.cpp)
   endif()
+  set(PYBIND11_MODULE_OPTIONS)
+  if (Kokkos_ENABLE_CUDA)
+    # GNU LTO merges CUDA fatbinary objects and emits duplicate fatbinData
+    # symbols while linking the Python module. NO_EXTRAS disables pybind11's
+    # automatic LTO for this target.
+    set(PYBIND11_MODULE_OPTIONS NO_EXTRAS)
+  endif()
   pybind11_add_module(PyOmega_h
+      ${PYBIND11_MODULE_OPTIONS}
       ${PYBIND11_SOURCES})
   target_link_libraries(PyOmega_h PUBLIC omega_h)
   # this is useful for direct CMake installation into python.


### PR DESCRIPTION
These changes were required to enable the builds with pybind11 turned on with GPU support in Omega_h.